### PR TITLE
Avoid nil pointer derefencing by upgrading go-eth2-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ethpandaops/dugtrio
 go 1.21.1
 
 require (
-	github.com/attestantio/go-eth2-client v0.18.3
+	github.com/attestantio/go-eth2-client v0.19.0
 	github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -27,6 +27,7 @@ require (
 	github.com/goccy/go-yaml v1.9.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/holiman/uint256 v1.2.2 // indirect
+	github.com/huandu/go-clone v1.6.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/attestantio/go-eth2-client v0.18.3 h1:hUSYh+uMLyw4mJcXWcvrPLd8ozJl61aWMdx5Cpq9hxk=
 github.com/attestantio/go-eth2-client v0.18.3/go.mod h1:KSVlZSW1A3jUg5H8O89DLtqxgJprRfTtI7k89fLdhu0=
+github.com/attestantio/go-eth2-client v0.19.0 h1:R0SS4PY0W22ntOEvh9F9tajY2tH4oZm3Y5FxFMk6Nrg=
+github.com/attestantio/go-eth2-client v0.19.0/go.mod h1:mZve1kV9Ctj0I1HH9gdg+MnI8lZ+Cb2EktEtOYrBlsM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -42,6 +44,7 @@ github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/holiman/uint256 v1.2.2 h1:TXKcSGc2WaxPD2+bmzAsVthL4+pEN0YwXcL5qED83vk=
 github.com/holiman/uint256 v1.2.2/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
 github.com/huandu/go-clone v1.6.0 h1:HMo5uvg4wgfiy5FoGOqlFLQED/VGRm2D9Pi8g1FXPGc=
 github.com/huandu/go-clone v1.6.0/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/go-clone/generic v1.6.0 h1:Wgmt/fUZ28r16F2Y3APotFD59sHk1p78K0XLdbUYN5U=

--- a/rpc/beaconapi.go
+++ b/rpc/beaconapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/attestantio/go-eth2-client/api"
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
@@ -75,7 +76,7 @@ func (bc *BeaconClient) GetGenesis() (*v1.Genesis, error) {
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Data, nil
 }
 
 func (bc *BeaconClient) GetNodeSyncing(ctx context.Context) (*v1.SyncState, error) {
@@ -87,7 +88,7 @@ func (bc *BeaconClient) GetNodeSyncing(ctx context.Context) (*v1.SyncState, erro
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Data, nil
 }
 
 type apiNodeVersion struct {
@@ -105,7 +106,7 @@ func (bc *BeaconClient) GetNodeVersion(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return result, nil
+	return result.Data, nil
 }
 
 func (bc *BeaconClient) GetConfigSpecs(ctx context.Context) (map[string]interface{}, error) {
@@ -117,7 +118,7 @@ func (bc *BeaconClient) GetConfigSpecs(ctx context.Context) (map[string]interfac
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Data, nil
 }
 
 func (bc *BeaconClient) GetLatestBlockHead(ctx context.Context) (*v1.BeaconBlockHeader, error) {
@@ -125,11 +126,13 @@ func (bc *BeaconClient) GetLatestBlockHead(ctx context.Context) (*v1.BeaconBlock
 	if !isProvider {
 		return nil, fmt.Errorf("get beacon block headers not supported")
 	}
-	result, err := provider.BeaconBlockHeader(ctx, "head")
+	// TODO - isn't the BeaconBlockHeaderOpts struct supposed to be different?
+	// TODO same with FinalityOps, etc (seems they should contain a CommonOpts field)
+	result, err := provider.BeaconBlockHeader(ctx, &api.BeaconBlockHeaderOpts{Block: "head"})
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Data, nil
 }
 
 func (bc *BeaconClient) GetFinalityCheckpoints(ctx context.Context) (*v1.Finality, error) {
@@ -137,11 +140,11 @@ func (bc *BeaconClient) GetFinalityCheckpoints(ctx context.Context) (*v1.Finalit
 	if !isProvider {
 		return nil, fmt.Errorf("get finality not supported")
 	}
-	result, err := provider.Finality(ctx, "head")
+	result, err := provider.Finality(ctx, &api.FinalityOpts{State: "head"})
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Data, nil
 }
 
 func (bc *BeaconClient) GetBlockHeaderByBlockroot(ctx context.Context, blockroot phase0.Root) (*v1.BeaconBlockHeader, error) {
@@ -149,11 +152,11 @@ func (bc *BeaconClient) GetBlockHeaderByBlockroot(ctx context.Context, blockroot
 	if !isProvider {
 		return nil, fmt.Errorf("get beacon block headers not supported")
 	}
-	result, err := provider.BeaconBlockHeader(ctx, fmt.Sprintf("0x%x", blockroot))
+	result, err := provider.BeaconBlockHeader(ctx, &api.BeaconBlockHeaderOpts{Block: fmt.Sprintf("0x%x", blockroot)})
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Data, nil
 }
 
 func (bc *BeaconClient) GetBlockHeaderBySlot(ctx context.Context, slot phase0.Slot) (*v1.BeaconBlockHeader, error) {
@@ -161,9 +164,9 @@ func (bc *BeaconClient) GetBlockHeaderBySlot(ctx context.Context, slot phase0.Sl
 	if !isProvider {
 		return nil, fmt.Errorf("get beacon block headers not supported")
 	}
-	result, err := provider.BeaconBlockHeader(ctx, fmt.Sprintf("%d", slot))
+	result, err := provider.BeaconBlockHeader(ctx, &api.BeaconBlockHeaderOpts{Block: fmt.Sprintf("%d", slot)})
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Data, nil
 }

--- a/rpc/beaconapi.go
+++ b/rpc/beaconapi.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/attestantio/go-eth2-client/api"
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
 	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/http"
 	"github.com/attestantio/go-eth2-client/spec/phase0"

--- a/rpc/beaconapi.go
+++ b/rpc/beaconapi.go
@@ -126,8 +126,6 @@ func (bc *BeaconClient) GetLatestBlockHead(ctx context.Context) (*v1.BeaconBlock
 	if !isProvider {
 		return nil, fmt.Errorf("get beacon block headers not supported")
 	}
-	// TODO - isn't the BeaconBlockHeaderOpts struct supposed to be different?
-	// TODO same with FinalityOps, etc (seems they should contain a CommonOpts field)
 	result, err := provider.BeaconBlockHeader(ctx, &api.BeaconBlockHeaderOpts{Block: "head"})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The currently used version of go-eth2-client (v.0.18.3) can lead to unhandled nil pointer dereferencing.

For example, I experienced the following when `GetBlockHeaderByBlockroot` occasionally led to a nil header being returned:
```
time="2025-04-21T13:48:36Z" level=error msg="uncaught panic in runUpstreamClientLoop subroutine: runtime error: invalid memory address or nil pointer dereference, stack: goroutine 20 [running]:\nruntime/debug.Stack()\n\t/opt/hostedtoolcache/go/1.21.13/x64/src/runtime/debug/stack.go:24 +0x5e\ngithub.com/ethpandaops/dugtrio/utils.HandleSubroutinePanic({0xb8892a, 0x15})\n\t/home/runner/work/dugtrio/dugtrio/utils/process.go:20 +0x9d\npanic({0xab7460?, 0x134cb60?})\n\t/opt/hostedtoolcache/go/1.21.13/x64/src/runtime/panic.go:914 +0x21f\ngithub.com/ethpandaops/dugtrio/pool.(*PoolClient).processBlockEvent.func1()\n\t/home/runner/work/dugtrio/dugtrio/pool/clientlogic.go:201 +0xfa\ngithub.com/ethpandaops/dugtrio/pool.(*CachedBlock).EnsureHeader(0xc0002e7c20, 0x5bdf4dc600000004?)\n\t/home/runner/work/dugtrio/dugtrio/pool/cachedblock.go:64 +0xae\ngithub.com/ethpandaops/dugtrio/pool.(*PoolClient).processBlockEvent(0xc00010b440, 0xc000201bc0)\n\t/home/runner/work/dugtrio/dugtrio/pool/clientlogic.go:194 +0x1f9\ngithub.com/ethpandaops/dugtrio/pool.(*PoolClient).runPoolClient(0xc00010b440)\n\t/home/runner/work/dugtrio/dugtrio/pool/clientlogic.go:138 +0x58f\ngithub.com/ethpandaops/dugtrio/pool.(*PoolClient).runPoolClientLoop(0xc00010b440)\n\t/home/runner/work/dugtrio/dugtrio/pool/clientlogic.go:22 +0x69\ncreated by github.com/ethpandaops/dugtrio/pool.(*BeaconPool).newPoolClient in goroutine 1\n\t/home/runner/work/dugtrio/dugtrio/pool/client.go:53 +0x1d9\n" error="runtime error: invalid memory address or nil pointer dereference"
```

The nil dereferencing appeared to come from https://github.com/ethpandaops/dugtrio/blob/767b79ab87ccd23d466316dca31b31f5bcebd97a/pool/clientlogic.go#L201.

The go-eth2-client release notes for v.0.19.0 specifically calls out that earlier versions of the library could return `{ nil, nil }`, which could lead to nil pointer dereferencing: https://github.com/attestantio/go-eth2-client/blob/master/docs/0.19.0-changes.md#no-more-nil-nil

After implementing the breaking changes required by v0.19.0, I was able to no longer reproduce this error