### PR TITLE
Propagate error on unhandled panic

### DIFF
--- a/utils/process.go
+++ b/utils/process.go
@@ -18,6 +18,7 @@ func WaitForCtrlC() {
 func HandleSubroutinePanic(identifier string) {
 	if err := recover(); err != nil {
 		logrus.WithError(err.(error)).Errorf("uncaught panic in %v subroutine: %v, stack: %v", identifier, err, string(debug.Stack()))
+		// re-raise error since it can't be recovered from
 		panic(err)
 	}
 }

--- a/utils/process.go
+++ b/utils/process.go
@@ -18,5 +18,6 @@ func WaitForCtrlC() {
 func HandleSubroutinePanic(identifier string) {
 	if err := recover(); err != nil {
 		logrus.WithError(err.(error)).Errorf("uncaught panic in %v subroutine: %v, stack: %v", identifier, err, string(debug.Stack()))
+		panic(err)
 	}
 }


### PR DESCRIPTION
When `processBlockEvent` in clientlogic.go led to an unhandled panic as described in #8 , the error was propagated to `HandleSubroutinePanic` in `process.go`. The existing implementation of `HandleSubroutinePanic` led to some undesirable behavior:
1. The main thread where blocks are retrevied via `runPoolClient` / `processBlockEvent` hung indefinitely and did not return any new blocks
2. The `/healthcheck` endpoint continued to return 200 OKs, so our load balancer never spawned a new instance

This PR doesn't fix the `/healthcheck` issue but at least makes sure an unhandled panic does not cause the application to hang
 