### PR TITLE
Add back missing return statement

### DIFF
--- a/pool/clientlogic.go
+++ b/pool/clientlogic.go
@@ -312,6 +312,7 @@ func (client *Client) setFinalizedHead(epoch phase0.Epoch, root phase0.Root) {
 
 	if bytes.Equal(client.finalizedRoot[:], root[:]) {
 		client.headMutex.Unlock()
+		return
 	}
 
 	client.finalizedEpoch = epoch


### PR DESCRIPTION
A return statement was taken out inadvertently and caused the headMutex to be unlocked more than once -- leading to unhandled panics

Addresses https://github.com/ethpandaops/dugtrio/issues/12