### PR TITLE
use separate sessions for client specific endpoints

### DIFF
--- a/frontend/handlers/sessions.go
+++ b/frontend/handlers/sessions.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ethpandaops/dugtrio/frontend"
+	"github.com/ethpandaops/dugtrio/pool"
 )
 
 type SessionsPage struct {
@@ -12,13 +14,19 @@ type SessionsPage struct {
 }
 
 type SessionsPageSession struct {
-	Index     int     `json:"index"`
-	Key       string  `json:"key"`
-	FirstSeen string  `json:"first_seen"`
-	LastSeen  string  `json:"last_seen"`
-	Requests  uint64  `json:"requests"`
-	Tokens    float64 `json:"tokens"`
-	Target    string  `json:"target"`
+	Index     int                          `json:"index"`
+	Key       string                       `json:"key"`
+	FirstSeen string                       `json:"first_seen"`
+	LastSeen  string                       `json:"last_seen"`
+	Requests  uint64                       `json:"requests"`
+	Tokens    float64                      `json:"tokens"`
+	Target    string                       `json:"target"`
+	Targets   []*SessionsPageSessionTarget `json:"targets"`
+}
+
+type SessionsPageSessionTarget struct {
+	Prefix string `json:"prefix"`
+	Target string `json:"target"`
 }
 
 // Sessions will return the "sessions" page using a go template
@@ -48,20 +56,39 @@ func (fh *FrontendHandler) getSessionsPageData() (*SessionsPage, error) {
 		Sessions: []*SessionsPageSession{},
 	}
 
-	// get sessions
-	for index, session := range fh.proxy.GetSessions() {
+	for index, group := range fh.proxy.GetSessionGroups() {
 		sessionData := &SessionsPageSession{
 			Index:     index + 1,
-			Key:       session.GetIPAddr(),
-			FirstSeen: session.GetFirstSeen().Format("2006-01-02 15:04:05"),
-			LastSeen:  session.GetLastSeen().Format("2006-01-02 15:04:05"),
-			Requests:  session.GetRequests(),
-			Tokens:    session.GetLimiterTokens(),
+			Key:       group.GetIPAddr(),
+			FirstSeen: group.GetFirstSeen().Format("2006-01-02 15:04:05"),
+			LastSeen:  group.GetLastSeen().Format("2006-01-02 15:04:05"),
+			Requests:  group.GetRequests(),
+			Tokens:    group.GetLimiterTokens(),
 			Target:    "",
+			Targets:   []*SessionsPageSessionTarget{},
 		}
 
-		if lastClient := session.GetLastPoolClient(); lastClient != nil {
-			sessionData.Target = lastClient.GetName()
+		for _, session := range group.GetSessions() {
+			prefix := "main"
+			if session.GetPrefix() != pool.UnspecifiedClient {
+				prefix = session.GetPrefix().String()
+			}
+
+			target := ""
+			if lastClient := session.GetLastPoolClient(); lastClient != nil {
+				target = lastClient.GetName()
+			}
+
+			if sessionData.Target != "" {
+				sessionData.Target += ", "
+			}
+
+			sessionData.Target += fmt.Sprintf("%s: %s", prefix, target)
+
+			sessionData.Targets = append(sessionData.Targets, &SessionsPageSessionTarget{
+				Prefix: prefix,
+				Target: target,
+			})
 		}
 
 		pageData.Sessions = append(pageData.Sessions, sessionData)

--- a/proxy/beaconproxy.go
+++ b/proxy/beaconproxy.go
@@ -309,9 +309,11 @@ func (proxy *BeaconProxy) rebalanceSessions() {
 
 	for _, group := range proxy.sessions {
 		group.sessionMutex.Lock()
+
 		for _, session := range group.sessions {
 			allSessions = append(allSessions, session)
 		}
+
 		group.sessionMutex.Unlock()
 	}
 

--- a/proxy/beaconproxy.go
+++ b/proxy/beaconproxy.go
@@ -61,7 +61,7 @@ type BeaconProxy struct {
 	blockedPaths []*regexp.Regexp
 
 	sessionMutex sync.Mutex
-	sessions     map[string]*Session
+	sessions     map[string]*SessionGroup
 }
 
 func NewBeaconProxy(config *types.ProxyConfig, beaconPool *pool.BeaconPool, proxyMetrics *metrics.ProxyMetrics) (*BeaconProxy, error) {
@@ -71,7 +71,7 @@ func NewBeaconProxy(config *types.ProxyConfig, beaconPool *pool.BeaconPool, prox
 		proxyMetrics: proxyMetrics,
 		logger:       logrus.WithField("module", "proxy"),
 		blockedPaths: []*regexp.Regexp{},
-		sessions:     map[string]*Session{},
+		sessions:     make(map[string]*SessionGroup),
 	}
 
 	blockedPaths := []string{}
@@ -114,7 +114,7 @@ func NewBeaconProxy(config *types.ProxyConfig, beaconPool *pool.BeaconPool, prox
 }
 
 func (proxy *BeaconProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	proxy.processCall(w, r, pool.UnspecifiedClient)
+	proxy.processCall(w, r, pool.UnspecifiedClient, pool.UnspecifiedClient)
 }
 
 func (proxy *BeaconProxy) ServeHealthCheckHTTP(w http.ResponseWriter, _ *http.Request) {
@@ -138,7 +138,7 @@ func (proxy *BeaconProxy) ServeHealthCheckHTTP(w http.ResponseWriter, _ *http.Re
 	}
 }
 
-func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, clientType pool.ClientType) {
+func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, clientType, sessionPrefix pool.ClientType) {
 	if proxy.checkBlockedPaths(r.URL) {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusForbidden)
@@ -164,8 +164,8 @@ func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, cl
 		return
 	}
 
-	session := proxy.getSessionForRequest(r, identifier)
-	if session.checkCallLimit(1) != nil {
+	session := proxy.getSessionForRequest(r, identifier, sessionPrefix)
+	if session.group.checkCallLimit(1) != nil {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusTooManyRequests)
 
@@ -202,7 +202,7 @@ func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, cl
 		return
 	}
 
-	session.requests.Add(1)
+	session.group.requests.Add(1)
 
 	err = proxy.processProxyCall(w, r, session, endpoint)
 	if err != nil {
@@ -301,37 +301,50 @@ func (proxy *BeaconProxy) rebalanceSessions() {
 
 	readyClients := canonicalFork.ReadyClients
 
-	// Count sessions per endpoint
-	endpointCounts := make(map[*pool.Client]int)
-	for _, client := range readyClients {
-		endpointCounts[client] = 0
-	}
-
 	proxy.sessionMutex.Lock()
 	defer proxy.sessionMutex.Unlock()
 
+	// Collect all sessions across all groups.
+	allSessions := make([]*Session, 0, len(proxy.sessions)*2)
+
+	for _, group := range proxy.sessions {
+		group.sessionMutex.Lock()
+		for _, session := range group.sessions {
+			allSessions = append(allSessions, session)
+		}
+		group.sessionMutex.Unlock()
+	}
+
+	// Count total sessions per endpoint across all prefixes.
+	// This gives us the real load each endpoint is handling.
+	endpointTotals := make(map[*pool.Client]int, len(readyClients))
+	for _, client := range readyClients {
+		endpointTotals[client] = 0
+	}
+
 	totalSessions := 0
 
-	for _, session := range proxy.sessions {
+	for _, session := range allSessions {
 		if session.lastPoolClient != nil && slices.Contains(readyClients, session.lastPoolClient) {
-			endpointCounts[session.lastPoolClient]++
+			endpointTotals[session.lastPoolClient]++
 			totalSessions++
 		}
 	}
 
-	// Calculate ideal distribution
-	idealCount := float64(totalSessions) / float64(len(readyClients))
+	if totalSessions == 0 {
+		return
+	}
 
-	// Check if any endpoint exceeds threshold
+	idealTotal := float64(totalSessions) / float64(len(readyClients))
+
 	diff := 0.0
 	absDiff := 0
 
 	needsRebalance := func() bool {
-		for _, count := range endpointCounts {
-			diff = math.Abs(float64(count)-idealCount) / idealCount
-			absDiff = int(math.Abs(float64(count) - idealCount))
+		for _, count := range endpointTotals {
+			diff = math.Abs(float64(count)-idealTotal) / idealTotal
+			absDiff = int(math.Abs(float64(count) - idealTotal))
 
-			// Use the minimum of percentage and absolute thresholds
 			if diff > proxy.config.RebalanceThreshold && absDiff > proxy.config.RebalanceAbsThreshold {
 				return true
 			}
@@ -340,89 +353,139 @@ func (proxy *BeaconProxy) rebalanceSessions() {
 		return false
 	}
 
-	// Rebalance if needed
-	if needsRebalance() {
-		proxy.logger.Infof("Rebalancing sessions (threshold exceeded: ideal=%.2f, diff=%.2f%%, abs_diff=%v)", idealCount, diff*100, absDiff)
-
-		rebalancedCount := 0
-		rebalanceOne := func() bool {
-			// Sort endpoints by session count
-			type endpointCount struct {
-				client *pool.Client
-				count  int
-			}
-
-			counts := make([]endpointCount, 0, len(endpointCounts))
-
-			for client, count := range endpointCounts {
-				counts = append(counts, endpointCount{client, count})
-			}
-
-			if len(counts) <= 1 {
-				return false
-			}
-
-			sort.Slice(counts, func(i, j int) bool {
-				return counts[i].count > counts[j].count
-			})
-
-			var targetClient *pool.Client
-
-			var targetCountsIndex int
-
-			for i := len(counts) - 1; i > 0; i-- {
-				if slices.Contains(readyClients, counts[i].client) {
-					targetClient = counts[i].client
-					targetCountsIndex = i
-
-					break
-				}
-			}
-
-			if targetClient == nil || targetClient == counts[0].client {
-				return false
-			}
-
-			sessions := make([]*Session, 0, counts[0].count)
-			for _, session := range proxy.sessions {
-				if session.lastPoolClient == counts[0].client {
-					sessions = append(sessions, session)
-				}
-			}
-
-			sort.Slice(sessions, func(i, j int) bool {
-				return sessions[i].lastRebalance.Before(sessions[j].lastRebalance)
-			})
-
-			if len(sessions) == 0 {
-				return false
-			}
-
-			session := sessions[0]
-
-			session.setLastPoolClient(targetClient)
-
-			endpointCounts[counts[0].client]--
-			counts[0].count--
-			endpointCounts[targetClient]++
-			counts[targetCountsIndex].count++
-			rebalancedCount++
-
-			proxy.logger.Infof("Rebalanced session %v: %v -> %v", session.GetIPAddr(), counts[0].client.GetName(), targetClient.GetName())
-
-			return true
-		}
-
-		for rebalanceOne() {
-			if !needsRebalance() {
-				break
-			}
-
-			if proxy.config.RebalanceMaxSweep > 0 && rebalancedCount >= proxy.config.RebalanceMaxSweep {
-				break
-			}
-		}
-
-		proxy.logger.Infof("Rebalanced %d sessions (threshold exceeded: ideal=%.2f, diff=%.2f%%, abs_diff=%v)", rebalancedCount, idealCount, diff*100, absDiff)
+	if !needsRebalance() {
+		return
 	}
+
+	proxy.logger.Infof("Rebalancing sessions (ideal=%.2f, diff=%.2f%%, abs_diff=%v)", idealTotal, diff*100, absDiff)
+
+	rebalancedCount := 0
+
+	// Each iteration moves one session from the heaviest overloaded endpoint.
+	// Unconstrained sessions are preferred because they can target any endpoint.
+	// Constrained sessions can only move to endpoints of the same client type.
+	rebalanceOne := func() bool {
+		// Sort endpoints by total load, descending.
+		type epLoad struct {
+			client *pool.Client
+			total  int
+		}
+
+		loads := make([]epLoad, 0, len(endpointTotals))
+		for client, total := range endpointTotals {
+			loads = append(loads, epLoad{client, total})
+		}
+
+		sort.Slice(loads, func(i, j int) bool {
+			return loads[i].total > loads[j].total
+		})
+
+		// Try each overloaded endpoint, starting from the heaviest.
+		for srcIdx := range loads {
+			srcClient := loads[srcIdx].client
+			srcTotal := loads[srcIdx].total
+
+			if float64(srcTotal) <= idealTotal {
+				break
+			}
+
+			// Partition movable sessions on this endpoint by constraint type.
+			var unconstrained []*Session
+
+			constrained := make(map[pool.ClientType][]*Session, 2)
+
+			for _, session := range allSessions {
+				if session.lastPoolClient != srcClient {
+					continue
+				}
+
+				if session.prefix == pool.UnspecifiedClient {
+					unconstrained = append(unconstrained, session)
+				} else {
+					constrained[session.prefix] = append(constrained[session.prefix], session)
+				}
+			}
+
+			// Try unconstrained first — can target any underloaded endpoint.
+			if len(unconstrained) > 0 {
+				// Find most underloaded endpoint (last in sorted list).
+				var target *pool.Client
+
+				for tIdx := len(loads) - 1; tIdx > srcIdx; tIdx-- {
+					if loads[tIdx].total < srcTotal {
+						target = loads[tIdx].client
+
+						break
+					}
+				}
+
+				if target != nil {
+					sort.Slice(unconstrained, func(i, j int) bool {
+						return unconstrained[i].lastRebalance.Before(unconstrained[j].lastRebalance)
+					})
+
+					session := unconstrained[0]
+					session.setLastPoolClient(target)
+
+					endpointTotals[srcClient]--
+					endpointTotals[target]++
+					rebalancedCount++
+
+					proxy.logger.Infof("Rebalanced session %v [main]: %v -> %v",
+						session.group.GetIPAddr(),
+						srcClient.GetName(), target.GetName())
+
+					return true
+				}
+			}
+
+			// Try constrained — can only target underloaded endpoints of same type.
+			for clientType, candidates := range constrained {
+				var target *pool.Client
+
+				for tIdx := len(loads) - 1; tIdx > srcIdx; tIdx-- {
+					if loads[tIdx].client.GetClientType() == clientType && loads[tIdx].total < srcTotal {
+						target = loads[tIdx].client
+
+						break
+					}
+				}
+
+				if target == nil {
+					continue
+				}
+
+				sort.Slice(candidates, func(i, j int) bool {
+					return candidates[i].lastRebalance.Before(candidates[j].lastRebalance)
+				})
+
+				session := candidates[0]
+				session.setLastPoolClient(target)
+
+				endpointTotals[srcClient]--
+				endpointTotals[target]++
+				rebalancedCount++
+
+				proxy.logger.Infof("Rebalanced session %v [%v]: %v -> %v",
+					session.group.GetIPAddr(), session.prefix,
+					srcClient.GetName(), target.GetName())
+
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for rebalanceOne() {
+		if !needsRebalance() {
+			break
+		}
+
+		if proxy.config.RebalanceMaxSweep > 0 && rebalancedCount >= proxy.config.RebalanceMaxSweep {
+			break
+		}
+	}
+
+	proxy.logger.Infof("Rebalanced %d sessions", rebalancedCount)
 }

--- a/proxy/clientspecificproxy.go
+++ b/proxy/clientspecificproxy.go
@@ -39,5 +39,5 @@ func (proxy *ClientSpecificProxy) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		// Otherwise keep the full path intact for client-specific endpoints
 	}
 
-	proxy.beaconProxy.processCall(w, r, proxy.clientType)
+	proxy.beaconProxy.processCall(w, r, proxy.clientType, proxy.clientType)
 }

--- a/proxy/proxycall.go
+++ b/proxy/proxycall.go
@@ -219,7 +219,9 @@ func (proxy *BeaconProxy) processEventStreamResponse(callContext *proxyCallConte
 			return written, nil
 		}
 
-		session.group.lastSeen = time.Now()
+		now := time.Now()
+		session.group.lastSeen = now
+		session.lastSeen = now
 
 		callContext.updateChan <- proxy.config.CallTimeout
 	}

--- a/proxy/proxycall.go
+++ b/proxy/proxycall.go
@@ -146,8 +146,8 @@ func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Reques
 	}
 
 	respH.Set("X-Dugtrio-Version", fmt.Sprintf("dugtrio/%v", utils.GetVersion()))
-	respH.Set("X-Dugtrio-Session-Ip", session.GetIPAddr())
-	respH.Set("X-Dugtrio-Session-Tokens", fmt.Sprintf("%.2f", session.getCallLimitTokens()))
+	respH.Set("X-Dugtrio-Session-Ip", session.group.GetIPAddr())
+	respH.Set("X-Dugtrio-Session-Tokens", fmt.Sprintf("%.2f", session.group.getCallLimitTokens()))
 	respH.Set("X-Dugtrio-Endpoint-Name", endpoint.GetName())
 	respH.Set("X-Dugtrio-Endpoint-Type", endpoint.GetClientType().String())
 	respH.Set("X-Dugtrio-Endpoint-Version", endpoint.GetVersion())
@@ -183,7 +183,7 @@ func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Reques
 		respLen = rspLen
 	}
 
-	proxy.logger.Debugf("proxied %v %v call (ip: %v, status: %v, length: %v, endpoint: %v)", r.Method, r.URL.EscapedPath(), session.GetIPAddr(), resp.StatusCode, respLen, endpoint.GetName())
+	proxy.logger.Debugf("proxied %v %v call (ip: %v, status: %v, length: %v, endpoint: %v)", r.Method, r.URL.EscapedPath(), session.group.GetIPAddr(), resp.StatusCode, respLen, endpoint.GetName())
 
 	return nil
 }
@@ -219,7 +219,7 @@ func (proxy *BeaconProxy) processEventStreamResponse(callContext *proxyCallConte
 			return written, nil
 		}
 
-		session.updateLastSeen()
+		session.group.lastSeen = time.Now()
 
 		callContext.updateChan <- proxy.config.CallTimeout
 	}

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -16,14 +16,30 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// SessionGroup holds shared state for all sessions from the same IP/ident.
+// The rate limiter and request counter are shared across all prefix-specific
+// sessions within the group, so rate limits apply per-client regardless of
+// which prefix endpoints they use.
+type SessionGroup struct {
+	ipAddr    string
+	limiter   *rate.Limiter
+	firstSeen time.Time
+	lastSeen  time.Time
+	requests  atomic.Uint64
+
+	sessionMutex sync.Mutex
+	sessions     map[pool.ClientType]*Session
+}
+
+// Session holds per-prefix state for sticky endpoint selection and active
+// connections. Each client-specific prefix (e.g. /lighthouse/, /prysm/) and
+// the main endpoint get their own Session so their sticky endpoint choices
+// don't interfere with each other.
 type Session struct {
-	ipAddr         string
-	limiter        *rate.Limiter
-	firstSeen      time.Time
-	lastSeen       time.Time
+	group          *SessionGroup
+	prefix         pool.ClientType
 	lastPoolClient *pool.Client
 	lastRebalance  time.Time
-	requests       atomic.Uint64
 	activeContexts struct {
 		sync.Mutex
 		contexts map[uint64]context.CancelFunc
@@ -35,7 +51,7 @@ func (session *Session) init() {
 	session.activeContexts.contexts = make(map[uint64]context.CancelFunc)
 }
 
-func (proxy *BeaconProxy) getSessionForRequest(r *http.Request, ident string) *Session {
+func (proxy *BeaconProxy) getSessionForRequest(r *http.Request, ident string, prefix pool.ClientType) *Session {
 	var ip string
 
 	if proxy.config.ProxyCount > 0 {
@@ -63,39 +79,75 @@ func (proxy *BeaconProxy) getSessionForRequest(r *http.Request, ident string) *S
 		ip = fmt.Sprintf("%s-%s", ip, ident)
 	}
 
-	session := proxy.sessions[ip]
+	group := proxy.sessions[ip]
+	if group == nil {
+		group = &SessionGroup{
+			ipAddr:    ip,
+			firstSeen: time.Now(),
+			lastSeen:  time.Now(),
+			sessions:  make(map[pool.ClientType]*Session, 4),
+		}
+
+		if proxy.config.CallRateLimit > 0 {
+			group.limiter = rate.NewLimiter(rate.Limit(proxy.config.CallRateLimit), proxy.config.CallRateBurst)
+		}
+
+		proxy.sessions[ip] = group
+	} else {
+		group.lastSeen = time.Now()
+	}
+
+	group.sessionMutex.Lock()
+	defer group.sessionMutex.Unlock()
+
+	session := group.sessions[prefix]
 	if session == nil {
 		session = &Session{
-			ipAddr:        ip,
-			firstSeen:     time.Now(),
-			lastSeen:      time.Now(),
+			group:         group,
+			prefix:        prefix,
 			lastRebalance: time.Now(),
 		}
 		session.init()
 
-		if proxy.config.CallRateLimit > 0 {
-			session.limiter = rate.NewLimiter(rate.Limit(proxy.config.CallRateLimit), proxy.config.CallRateBurst)
-		}
-
-		proxy.sessions[ip] = session
-	} else {
-		session.lastSeen = time.Now()
+		group.sessions[prefix] = session
 	}
 
 	return session
 }
 
-func (proxy *BeaconProxy) GetSessions() []*Session {
+// GetSessionGroups returns all session groups sorted by firstSeen.
+func (proxy *BeaconProxy) GetSessionGroups() []*SessionGroup {
 	proxy.sessionMutex.Lock()
 	defer proxy.sessionMutex.Unlock()
 
-	sessions := []*Session{}
-	for _, session := range proxy.sessions {
-		sessions = append(sessions, session)
+	groups := make([]*SessionGroup, 0, len(proxy.sessions))
+	for _, group := range proxy.sessions {
+		groups = append(groups, group)
+	}
+
+	sort.Slice(groups, func(a, b int) bool {
+		return groups[b].firstSeen.After(groups[a].firstSeen)
+	})
+
+	return groups
+}
+
+// GetAllSessions returns all prefix-specific sessions across all groups.
+func (proxy *BeaconProxy) GetAllSessions() []*Session {
+	proxy.sessionMutex.Lock()
+	defer proxy.sessionMutex.Unlock()
+
+	sessions := make([]*Session, 0, len(proxy.sessions)*2)
+	for _, group := range proxy.sessions {
+		group.sessionMutex.Lock()
+		for _, session := range group.sessions {
+			sessions = append(sessions, session)
+		}
+		group.sessionMutex.Unlock()
 	}
 
 	sort.Slice(sessions, func(a, b int) bool {
-		return sessions[b].firstSeen.After(sessions[a].firstSeen)
+		return sessions[b].group.firstSeen.After(sessions[a].group.firstSeen)
 	})
 
 	return sessions
@@ -109,8 +161,8 @@ func (proxy *BeaconProxy) cleanupSessions() {
 
 		proxy.sessionMutex.Lock()
 
-		for ip, session := range proxy.sessions {
-			if time.Since(session.lastSeen) > proxy.config.SessionTimeout {
+		for ip, group := range proxy.sessions {
+			if time.Since(group.lastSeen) > proxy.config.SessionTimeout {
 				delete(proxy.sessions, ip)
 			}
 		}
@@ -119,56 +171,77 @@ func (proxy *BeaconProxy) cleanupSessions() {
 	}
 }
 
-func (session *Session) checkCallLimit(callCost int) error {
-	if session.limiter == nil {
+// SessionGroup methods
+
+func (group *SessionGroup) checkCallLimit(callCost int) error {
+	if group.limiter == nil {
 		return nil
 	}
 
-	if !session.limiter.AllowN(time.Now(), callCost) {
+	if !group.limiter.AllowN(time.Now(), callCost) {
 		return fmt.Errorf("call rate limit exceeded")
 	}
 
 	return nil
 }
 
-func (session *Session) getCallLimitTokens() float64 {
-	if session.limiter == nil {
+func (group *SessionGroup) getCallLimitTokens() float64 {
+	if group.limiter == nil {
 		return 0
 	}
 
-	return session.limiter.Tokens()
+	return group.limiter.Tokens()
 }
 
-func (session *Session) GetIPAddr() string {
-	return session.ipAddr
+func (group *SessionGroup) GetIPAddr() string {
+	return group.ipAddr
 }
 
-func (session *Session) GetFirstSeen() time.Time {
-	return session.firstSeen
+func (group *SessionGroup) GetFirstSeen() time.Time {
+	return group.firstSeen
 }
 
-func (session *Session) GetLastSeen() time.Time {
-	return session.lastSeen
+func (group *SessionGroup) GetLastSeen() time.Time {
+	return group.lastSeen
+}
+
+func (group *SessionGroup) GetRequests() uint64 {
+	return group.requests.Load()
+}
+
+func (group *SessionGroup) GetLimiterTokens() float64 {
+	if group.limiter == nil {
+		return 0
+	}
+
+	return group.limiter.Tokens()
+}
+
+// GetSessions returns all prefix sessions within this group.
+func (group *SessionGroup) GetSessions() []*Session {
+	group.sessionMutex.Lock()
+	defer group.sessionMutex.Unlock()
+
+	sessions := make([]*Session, 0, len(group.sessions))
+	for _, session := range group.sessions {
+		sessions = append(sessions, session)
+	}
+
+	return sessions
+}
+
+// Session methods
+
+func (session *Session) GetGroup() *SessionGroup {
+	return session.group
+}
+
+func (session *Session) GetPrefix() pool.ClientType {
+	return session.prefix
 }
 
 func (session *Session) GetLastPoolClient() *pool.Client {
 	return session.lastPoolClient
-}
-
-func (session *Session) GetRequests() uint64 {
-	return session.requests.Load()
-}
-
-func (session *Session) GetLimiterTokens() float64 {
-	if session.limiter == nil {
-		return 0
-	}
-
-	return session.limiter.Tokens()
-}
-
-func (session *Session) updateLastSeen() {
-	session.lastSeen = time.Now()
 }
 
 func (session *Session) addActiveContext(cancel context.CancelFunc) uint64 {

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -38,6 +38,7 @@ type SessionGroup struct {
 type Session struct {
 	group          *SessionGroup
 	prefix         pool.ClientType
+	lastSeen       time.Time
 	lastPoolClient *pool.Client
 	lastRebalance  time.Time
 	activeContexts struct {
@@ -100,16 +101,21 @@ func (proxy *BeaconProxy) getSessionForRequest(r *http.Request, ident string, pr
 	group.sessionMutex.Lock()
 	defer group.sessionMutex.Unlock()
 
+	now := time.Now()
+
 	session := group.sessions[prefix]
 	if session == nil {
 		session = &Session{
 			group:         group,
 			prefix:        prefix,
-			lastRebalance: time.Now(),
+			lastSeen:      now,
+			lastRebalance: now,
 		}
 		session.init()
 
 		group.sessions[prefix] = session
+	} else {
+		session.lastSeen = now
 	}
 
 	return session
@@ -165,8 +171,22 @@ func (proxy *BeaconProxy) cleanupSessions() {
 
 		for ip, group := range proxy.sessions {
 			if time.Since(group.lastSeen) > proxy.config.SessionTimeout {
+				// Entire group expired, remove it.
 				delete(proxy.sessions, ip)
+
+				continue
 			}
+
+			// Expire individual prefix sessions within the group.
+			group.sessionMutex.Lock()
+
+			for prefix, session := range group.sessions {
+				if time.Since(session.lastSeen) > proxy.config.SessionTimeout {
+					delete(group.sessions, prefix)
+				}
+			}
+
+			group.sessionMutex.Unlock()
 		}
 
 		proxy.sessionMutex.Unlock()

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -140,9 +140,11 @@ func (proxy *BeaconProxy) GetAllSessions() []*Session {
 	sessions := make([]*Session, 0, len(proxy.sessions)*2)
 	for _, group := range proxy.sessions {
 		group.sessionMutex.Lock()
+
 		for _, session := range group.sessions {
 			sessions = append(sessions, session)
 		}
+
 		group.sessionMutex.Unlock()
 	}
 


### PR DESCRIPTION
## Summary

- **Separate sessions per prefix**: Introduces `SessionGroup` (shared per IP/ident: rate limiter, request counter) and per-prefix `Session` (sticky endpoint, active connections). The main endpoint (`/eth/`) and each client-specific endpoint (`/lighthouse/`, `/prysm/`, etc.) now get independent sticky endpoint tracking, preventing constant upstream switches when using prefixed endpoints in parallel.
- **Shared rate limiting**: The request rate limiter still applies across all prefix sessions within the same `SessionGroup`, so a single client can't bypass limits by splitting requests across prefixes.
- **Load-aware rebalancing**: Session rebalancing now considers total load per endpoint across all prefixes. It prioritizes draining the heaviest overloaded endpoints first, preferring to move unconstrained (main) sessions for maximum flexibility. Constrained (client-specific) sessions are only moved to endpoints of the same client type.

## Problem

When a client used client-specific endpoints (`/lighthouse/`, `/prysm/`, ...) in parallel with the main endpoint, they all shared a single session with one sticky endpoint reference. Each request through a different prefix would overwrite `lastPoolClient`, causing the sticky endpoint to constantly flip between upstream servers.

## Design

### SessionGroup + Session split

```
SessionGroup (per IP/ident)
├── rate limiter (shared)
├── request counter (shared)
├── firstSeen / lastSeen
└── sessions map[ClientType]*Session
    ├── UnspecifiedClient → Session (main /eth/ sticky endpoint)
    ├── LighthouseClient → Session (/lighthouse/ sticky endpoint)
    ├── PrysmClient      → Session (/prysm/ sticky endpoint)
    └── ...
```

### Rebalancing strategy

The rebalancer works on **total load per endpoint** (sum of all prefix sessions), not per-prefix independently. This prevents imbalance when one client type attracts disproportionate traffic:

1. Compute ideal load = total sessions / number of ready endpoints
2. Sort endpoints by total load, descending
3. For the heaviest overloaded endpoint:
   - Prefer moving **unconstrained** sessions (can target any underloaded endpoint)
   - Fall back to **constrained** sessions (can only move to same client type)
   - Target is always the most underloaded eligible endpoint
4. Repeat until thresholds met or sweep limit reached

This ensures unconstrained sessions compensate for the fixed load from constrained sessions.

## Changed files

| File | Change |
|---|---|
| `proxy/session.go` | Split `Session` into `SessionGroup` + `Session`; rate limiting and request counting moved to group; sticky endpoint and active contexts stay per-session |
| `proxy/beaconproxy.go` | `processCall` takes session prefix; sessions map stores `SessionGroup`; rebalancing uses total-load-aware algorithm |
| `proxy/clientspecificproxy.go` | Passes client type as session prefix |
| `proxy/proxycall.go` | Session IP and token accessors go through `session.group` |
| `frontend/handlers/sessions.go` | Uses `GetSessionGroups()`; shows per-prefix targets for each group |

## References
fix for #48 