### PR TITLE
ci: drop macos/amd64 release builds

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -147,39 +147,6 @@ jobs:
         path: ./bin/*
         name: dugtrio_windows_amd64
 
-  build_darwin_amd64_binary:
-    name: Build macos/amd64 binary
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
-
-    # setup global dependencies
-    - name: Set up go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: 1.25.x
-
-    # setup project dependencies
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-
-    # build binaries
-    - name: Build macos amd64 binary
-      run: |
-        make build
-      env:
-        RELEASE: ${{ inputs.release }}
-
-    # upload artifacts
-    - name: "Upload artifact: dugtrio_darwin_amd64"
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        path: ./bin/*
-        name: dugtrio_darwin_amd64
-
   build_darwin_arm64_binary:
     name: Build macos/arm64 binary
     runs-on: macos-latest

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -105,10 +105,6 @@ jobs:
       run: |
         cd dugtrio_linux_arm64
         tar -czf ../dugtrio_snapshot_linux_arm64.tar.gz .
-    - name: "Generate release package: dugtrio_snapshot_darwin_amd64.tar.gz"
-      run: |
-        cd dugtrio_darwin_amd64
-        tar -czf ../dugtrio_snapshot_darwin_amd64.tar.gz .
     - name: "Generate release package: dugtrio_snapshot_darwin_arm64.tar.gz"
       run: |
         cd dugtrio_darwin_arm64
@@ -131,11 +127,9 @@ jobs:
           | [dugtrio_snapshot_windows_amd64.zip](https://github.com/ethpandaops/dugtrio/releases/download/snapshot/dugtrio_snapshot_windows_amd64.zip) | dugtrio executables for windows/amd64 |
           | [dugtrio_snapshot_linux_amd64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/snapshot/dugtrio_snapshot_linux_amd64.tar.gz) | dugtrio executables for linux/amd64 |
           | [dugtrio_snapshot_linux_arm64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/snapshot/dugtrio_snapshot_linux_arm64.tar.gz) | dugtrio executables for linux/arm64 |
-          | [dugtrio_snapshot_darwin_amd64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/snapshot/dugtrio_snapshot_darwin_amd64.tar.gz) | dugtrio executable for macos/amd64 |
           | [dugtrio_snapshot_darwin_arm64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/snapshot/dugtrio_snapshot_darwin_arm64.tar.gz) | dugtrio executable for macos/arm64 |
         files: |
           dugtrio_snapshot_windows_amd64.zip
           dugtrio_snapshot_linux_amd64.tar.gz
           dugtrio_snapshot_linux_arm64.tar.gz
-          dugtrio_snapshot_darwin_amd64.tar.gz
           dugtrio_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,10 +79,6 @@ jobs:
       run: |
         cd dugtrio_linux_arm64
         tar -czf ../dugtrio_${{ inputs.version }}_linux_arm64.tar.gz .
-    - name: "Generate release package: dugtrio_${{ inputs.version }}_darwin_amd64.tar.gz"
-      run: |
-        cd dugtrio_darwin_amd64
-        tar -czf ../dugtrio_${{ inputs.version }}_darwin_amd64.tar.gz .
     - name: "Generate release package: dugtrio_${{ inputs.version }}_darwin_arm64.tar.gz"
       run: |
         cd dugtrio_darwin_arm64
@@ -114,11 +110,9 @@ jobs:
           | [dugtrio_${{ inputs.version }}_windows_amd64.zip](https://github.com/ethpandaops/dugtrio/releases/download/v${{ inputs.version }}/dugtrio_${{ inputs.version }}_windows_amd64.zip) | dugtrio executables for windows/amd64 |
           | [dugtrio_${{ inputs.version }}_linux_amd64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/v${{ inputs.version }}/dugtrio_${{ inputs.version }}_linux_amd64.tar.gz) | dugtrio executables for linux/amd64 |
           | [dugtrio_${{ inputs.version }}_linux_arm64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/v${{ inputs.version }}/dugtrio_${{ inputs.version }}_linux_arm64.tar.gz) | dugtrio executables for linux/arm64 |
-          | [dugtrio_${{ inputs.version }}_darwin_amd64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/v${{ inputs.version }}/dugtrio_${{ inputs.version }}_darwin_amd64.tar.gz) | dugtrio executable for macos/amd64 |
           | [dugtrio_${{ inputs.version }}_darwin_arm64.tar.gz](https://github.com/ethpandaops/dugtrio/releases/download/v${{ inputs.version }}/dugtrio_${{ inputs.version }}_darwin_arm64.tar.gz) | dugtrio executable for macos/arm64 |
         files: |
           dugtrio_${{ inputs.version }}_windows_amd64.zip
           dugtrio_${{ inputs.version }}_linux_amd64.tar.gz
           dugtrio_${{ inputs.version }}_linux_arm64.tar.gz
-          dugtrio_${{ inputs.version }}_darwin_amd64.tar.gz
           dugtrio_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- Remove the `build_darwin_amd64_binary` job from the shared build workflow
- Drop the darwin_amd64 tarball steps, release-notes table row, and files entry from snapshot/release workflows
- Mac builds are now arm64-only

## Test plan
- [ ] Trigger snapshot build and confirm artifacts contain only windows_amd64, linux_amd64, linux_arm64, darwin_arm64
- [ ] On the next tagged release, confirm artifacts and release-notes table match