### PR TITLE
[codex] fix security alerts

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -3,10 +3,6 @@ name: Reusable build workflow
 on:
   workflow_call:
     inputs:
-      ref:
-        description: 'The branch, tag or SHA to build'
-        required: true
-        type: string
       release:
         description: 'Release version tag for this build'
         default: ''
@@ -15,7 +11,7 @@ on:
       docker:
         description: 'Build docker images'
         default: false
-        required: true
+        required: false
         type: boolean
       docker_repository:
         description: 'Docker Hub Repository'
@@ -40,22 +36,25 @@ on:
         description: 'Docker Hub Token'
         required: false
 
+permissions:
+  contents: read
+
 # shared build jobs
 jobs:
   build_linux_amd64_binary:
     name: Build linux/amd64 binary
     runs-on: ubuntu-latest
+    outputs:
+      artifact_id: ${{ steps.upload_binary.outputs.artifact-id }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.25.x
-    
+
     # setup project dependencies
     - name: Get dependencies
       run: |
@@ -70,18 +69,19 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: dugtrio_linux_amd64"
+      id: upload_binary
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         path: ./bin/*
         name: dugtrio_linux_amd64
-  
+
   build_linux_arm64_binary:
     name: Build linux/arm64 binary
     runs-on: ubuntu-latest
+    outputs:
+      artifact_id: ${{ steps.upload_binary.outputs.artifact-id }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
@@ -94,7 +94,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install gcc-aarch64-linux-gnu libstdc++-11-dev-arm64-cross libstdc++-12-dev-arm64-cross
-    
+
     # setup project dependencies
     - name: Get dependencies
       run: |
@@ -109,6 +109,7 @@ jobs:
 
     # upload artifacts
     - name: "Upload artifact: dugtrio_linux_arm64"
+      id: upload_binary
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         path: ./bin/*
@@ -119,8 +120,6 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
@@ -152,8 +151,6 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     # setup global dependencies
     - name: Set up go
@@ -187,8 +184,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
 
     - name: Get build version
       id: vars
@@ -207,7 +202,8 @@ jobs:
     - name: Download build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: dugtrio_linux_amd64
+        artifact-ids: ${{ needs.build_linux_amd64_binary.outputs.artifact_id }}
+        merge-multiple: true
         path: ./bin
 
     # prepare environment
@@ -215,7 +211,7 @@ jobs:
       run: |
         chmod +x ./bin/*
         ls -lach ./bin
-    
+
     # build amd64 image
     - name: Build amd64 docker image
       run: |
@@ -227,7 +223,7 @@ jobs:
       run: |
         docker push ${{ inputs.docker_repository }}:${{ inputs.docker_tag_prefix }}-amd64
         docker push ${{ inputs.docker_repository }}:${{ inputs.docker_tag_prefix }}-${{ steps.vars.outputs.sha_short }}-amd64
-  
+
   build_arm64_docker_image:
     name: Build arm64 docker image
     needs: [build_linux_arm64_binary]
@@ -235,8 +231,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
     - name: Get build version
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -256,7 +250,8 @@ jobs:
     - name: Download build artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: dugtrio_linux_arm64
+        artifact-ids: ${{ needs.build_linux_arm64_binary.outputs.artifact_id }}
+        merge-multiple: true
         path: ./bin
 
     # prepare environment
@@ -264,7 +259,7 @@ jobs:
       run: |
         chmod +x ./bin/*
         ls -lach ./bin
-    
+
     # build arm64 image
     - name: Build arm64 docker image
       run: |
@@ -284,8 +279,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
     - name: Get build version
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -298,7 +291,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
+
     # build multiarch image
     - name: Build multiarch docker manifest
       run: |
@@ -316,8 +309,6 @@ jobs:
         tag: ${{ fromJSON(inputs.additional_tags) }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
     - name: Get build version
       id: vars
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -330,7 +321,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
+
     # build multiarch image
     - name: "Build additional docker manifest: ${{ matrix.tag }}"
       run: |

--- a/.github/workflows/_shared-check.yaml
+++ b/.github/workflows/_shared-check.yaml
@@ -3,6 +3,9 @@ name: Reusable check workflow
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # shared check jobs
 jobs:
   check_source:

--- a/.github/workflows/build-dev-latest.yml
+++ b/.github/workflows/build-dev-latest.yml
@@ -22,7 +22,6 @@ jobs:
     needs: [check_source]
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ github.sha }}
       release: "snapshot"
       docker: true
       docker_repository: "ethpandaops/dugtrio"

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -2,7 +2,7 @@
 name: Build PR
 
 on:
-  pull_request_target:
+  pull_request:
     types: [synchronize]
   workflow_dispatch:
     inputs:
@@ -14,51 +14,55 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   prinfo:
     name: "Get PR info"
     runs-on: ubuntu-latest
     outputs:
       run_builds: ${{ steps.loadinfo.outputs.run_builds }}
-      commit_ref: ${{ steps.loadinfo.outputs.commit_ref }}
       build_docker: ${{ steps.loadinfo.outputs.build_docker }}
       docker_tag: ${{ steps.loadinfo.outputs.docker_tag }}
     steps:
     - name: "Load PR info"
       id: loadinfo
+      env:
+        HAS_DOCKER_IMAGE_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-docker-image') }}
+        SAME_REPOSITORY_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        MANUAL_DOCKER_TAG: ${{ inputs.docker_tag }}
       run: |
-        has_docker_image_label="${{ contains(github.event.pull_request.labels.*.name, 'build-docker-image') }}"
+        has_docker_image_label="$HAS_DOCKER_IMAGE_LABEL"
+        same_repository_pr="$SAME_REPOSITORY_PR"
         run_builds="$has_docker_image_label"
+        build_docker="false"
         echo "docker image label: $has_docker_image_label"
+        echo "same repository PR: $same_repository_pr"
 
         branch_name="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
         branch_name="$(echo "$branch_name" | sed 's/\//-/g')"
         echo "branch name: $branch_name"
 
-        commit_repo="$GITHUB_REPOSITORY"
-        commit_ref="${{ github.event.pull_request.head.sha }}"
-        if [[ -z "$commit_ref" ]]; then
-          commit_ref="${{ github.sha }}"
-        fi
-        
-        echo "repository: $commit_repo"
-        echo "commit: $commit_ref"
-        
-        manual_tag="${{ inputs.docker_tag }}"
+        manual_tag="$MANUAL_DOCKER_TAG"
         if [[ ! -z "$manual_tag" ]]; then
-          has_docker_image_label="true"
           branch_name="$manual_tag"
           run_builds="true"
+          build_docker="true"
+        elif [[ "$has_docker_image_label" == "true" ]] && [[ "$same_repository_pr" == "true" ]]; then
+          build_docker="true"
+        elif [[ "$has_docker_image_label" == "true" ]]; then
+          echo "Skipping docker push for forked PR; dispatch this workflow manually to publish a trusted build."
         fi
 
         if [[ "$branch_name" == "master" ]] || [[ "$branch_name" =~ ^v[0-9] ]]; then
           echo "Invalid branch name! Skipping builds"
           run_builds="false"
+          build_docker="false"
         fi
 
         echo "run_builds=$run_builds" >> $GITHUB_OUTPUT
-        echo "commit_ref=$commit_ref" >> $GITHUB_OUTPUT
-        echo "build_docker=$has_docker_image_label" >> $GITHUB_OUTPUT
+        echo "build_docker=$build_docker" >> $GITHUB_OUTPUT
         echo "docker_tag=$branch_name" >> $GITHUB_OUTPUT
 
   check_source:
@@ -70,11 +74,21 @@ jobs:
   build_binaries:
     name: "Build dugtrio"
     needs: [prinfo, check_source]
-    if: ${{ needs.prinfo.outputs.run_builds == 'true' }}
+    if: ${{ needs.prinfo.outputs.run_builds == 'true' && needs.prinfo.outputs.build_docker != 'true' }}
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ needs.prinfo.outputs.commit_ref }}
-      docker: ${{ needs.prinfo.outputs.build_docker == 'true' }}
+      docker: false
+      docker_repository: "ethpandaops/dugtrio"
+      docker_tag_prefix: ${{needs.prinfo.outputs.docker_tag}}
+      additional_tags: "['${{needs.prinfo.outputs.docker_tag}}','${{needs.prinfo.outputs.docker_tag}}-latest']"
+
+  build_binaries_and_docker:
+    name: "Build dugtrio and Docker image"
+    needs: [prinfo, check_source]
+    if: ${{ needs.prinfo.outputs.run_builds == 'true' && needs.prinfo.outputs.build_docker == 'true' }}
+    uses: ./.github/workflows/_shared-build.yaml
+    with:
+      docker: true
       docker_repository: "ethpandaops/dugtrio"
       docker_tag_prefix: ${{needs.prinfo.outputs.docker_tag}}
       additional_tags: "['${{needs.prinfo.outputs.docker_tag}}','${{needs.prinfo.outputs.docker_tag}}-latest']"

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -25,7 +25,6 @@ jobs:
     needs: [check_source]
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ github.sha }}
       release: "snapshot"
       docker: true
       docker_repository: "ethpandaops/dugtrio"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,6 @@ jobs:
     name: "Build dugtrio"
     uses: ./.github/workflows/_shared-build.yaml
     with:
-      ref: ${{ github.sha }}
       release: "v${{ inputs.version }}"
       docker: true
       docker_repository: "ethpandaops/dugtrio"

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check_source:
     name: "Run code checks"


### PR DESCRIPTION
## Summary

Mirrors the workflow hardening landed in ethpandaops/assertoor#183.

- Drops caller-controlled `ref` inputs from reusable check/build workflows so reusable jobs check out the event SHA instead of arbitrary PR-provided refs.
- Moves the PR build workflow (`build-dev.yml`) from `pull_request_target` to `pull_request` and adds explicit read-only default permissions.
- Splits PR binary builds from Docker publishing so fork PRs do not receive DockerHub secrets, while same-repository / manual trusted Docker publishing remains available.
- Adds explicit workflow permissions and switches internal artifact handoffs to artifact IDs to avoid artifact-name poisoning.

## Validation

- `actionlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)