### PR TITLE
ui: color Optimistic status badge blue to match Dora

### DIFF
--- a/frontend/templates/health/health.html
+++ b/frontend/templates/health/health.html
@@ -35,7 +35,7 @@
                       {{ else if eq $client.Status "synchronizing" }}
                         <span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff $client.LastRefresh }}">Synchronizing</span>
                       {{ else if eq $client.Status "optimistic" }}
-                        <span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff $client.LastRefresh }}">Optimistic</span>
+                        <span class="badge rounded-pill text-bg-info" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff $client.LastRefresh }}">Optimistic</span>
                       {{ else if eq $client.Status "offline" }}
                         <span class="badge rounded-pill text-bg-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff $client.LastRefresh }}, Error: {{ $client.LastError }}">Offline</span>
                       {{ else }}
@@ -175,7 +175,7 @@
     {{ else if eq .Client.Status "synchronizing" }}
       <span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff .Client.LastRefresh }}">Synchronizing</span>
     {{ else if eq .Client.Status "optimistic" }}
-      <span class="badge rounded-pill text-bg-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff .Client.LastRefresh }}">Optimistic</span>
+      <span class="badge rounded-pill text-bg-info" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff .Client.LastRefresh }}">Optimistic</span>
     {{ else if eq .Client.Status "offline" }}
       <span class="badge rounded-pill text-bg-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="Updated: {{ formatTimeDiff .Client.LastRefresh }}, Error: {{ .Client.LastError }}">Offline</span>
     {{ else }}


### PR DESCRIPTION
## Summary
- Switch the Optimistic client status badge from `text-bg-warning` (yellow) to `text-bg-info` (blue) on the health page, matching the styling used by [Dora](https://github.com/ethpandaops/dora).
- Visually distinguishes Optimistic from Synchronizing (still yellow) instead of sharing the same color.

## Test plan
- [ ] Load `/health` and confirm the Optimistic badge renders blue in both the Clients table and the Client Forks table.