### PR TITLE
feat: endpoint failover for unavailable data

### DIFF
--- a/dugtrio-config.example.yaml
+++ b/dugtrio-config.example.yaml
@@ -52,8 +52,7 @@ proxy:
     - ^/eth/v[0-9]+/debug/.*
 
   # endpoint failover: retry data queries on other ready endpoints when an endpoint
-  # cannot serve the requested data (404/500/501/503, connection error or timeout).
-  # the last endpoint that successfully served a path class is tried first.
+  # cannot serve the requested data (404/500/501/503 or connection error).
   #failoverDisabled: false
 
   # api path patterns (regex) eligible for endpoint failover (default: state queries)
@@ -64,8 +63,13 @@ proxy:
   # maximum number of alternate endpoints to try per call (negative = all ready endpoints)
   #failoverMaxAttempts: 8
 
-  # per-attempt timeout while alternate endpoints remain (the last attempt uses the remaining call timeout)
-  #failoverAttemptTimeout: 20s
+  # how long an attempt may stay silent before the next candidate endpoint is raced in
+  # parallel; the silent attempt keeps running until the call timeout, so slow endpoints
+  # get their full time to respond while hanging endpoints only cost latency
+  #failoverHedgeDelay: 20s
+
+  # maximum number of hedged attempts running in parallel per call
+  #failoverMaxParallel: 2
 
   # optional authorization
   auth:

--- a/dugtrio-config.example.yaml
+++ b/dugtrio-config.example.yaml
@@ -51,6 +51,22 @@ proxy:
   blockedPaths:
     - ^/eth/v[0-9]+/debug/.*
 
+  # endpoint failover: retry data queries on other ready endpoints when an endpoint
+  # cannot serve the requested data (404/500/501/503, connection error or timeout).
+  # the last endpoint that successfully served a path class is tried first.
+  #failoverDisabled: false
+
+  # api path patterns (regex) eligible for endpoint failover (default: state queries)
+  #failoverPaths:
+  #  - ^/eth/v[0-9]+/beacon/states/
+  #  - ^/eth/v[0-9]+/debug/beacon/states/
+
+  # maximum number of alternate endpoints to try per call (negative = all ready endpoints)
+  #failoverMaxAttempts: 8
+
+  # per-attempt timeout while alternate endpoints remain (the last attempt uses the remaining call timeout)
+  #failoverAttemptTimeout: 20s
+
   # optional authorization
   auth:
     required: false

--- a/proxy/beaconproxy.go
+++ b/proxy/beaconproxy.go
@@ -78,21 +78,18 @@ type BeaconProxy struct {
 	sessionMutex sync.Mutex
 	sessions     map[string]*SessionGroup
 
-	failoverPaths     []*regexp.Regexp
-	failoverMutex     sync.Mutex
-	failoverEndpoints map[string]string
+	failoverPaths []*regexp.Regexp
 }
 
 func NewBeaconProxy(config *types.ProxyConfig, beaconPool *pool.BeaconPool, proxyMetrics *metrics.ProxyMetrics) (*BeaconProxy, error) {
 	proxy := BeaconProxy{
-		config:            config,
-		pool:              beaconPool,
-		proxyMetrics:      proxyMetrics,
-		logger:            logrus.WithField("module", "proxy"),
-		blockedPaths:      []*regexp.Regexp{},
-		sessions:          make(map[string]*SessionGroup),
-		failoverPaths:     []*regexp.Regexp{},
-		failoverEndpoints: map[string]string{},
+		config:        config,
+		pool:          beaconPool,
+		proxyMetrics:  proxyMetrics,
+		logger:        logrus.WithField("module", "proxy"),
+		blockedPaths:  []*regexp.Regexp{},
+		sessions:      make(map[string]*SessionGroup),
+		failoverPaths: []*regexp.Regexp{},
 	}
 
 	blockedPaths := []string{}
@@ -381,22 +378,21 @@ func (proxy *BeaconProxy) newFailoverContext(r *http.Request, firstEndpoint *poo
 		return nil
 	}
 
-	pathClass := ""
+	pathMatched := false
 	reqPath := r.URL.EscapedPath()
 
 	for _, failoverPathPattern := range proxy.failoverPaths {
 		if failoverPathPattern.MatchString(reqPath) {
-			pathClass = failoverPathPattern.String()
+			pathMatched = true
 			break
 		}
 	}
 
-	if pathClass == "" {
+	if !pathMatched {
 		return nil
 	}
 
 	failoverCtx := &failoverContext{
-		pathClass:   pathClass,
 		maxAttempts: proxy.config.FailoverMaxAttempts,
 	}
 
@@ -415,7 +411,7 @@ func (proxy *BeaconProxy) newFailoverContext(r *http.Request, firstEndpoint *poo
 		failoverCtx.hasBody = true
 	}
 
-	failoverCtx.candidates = proxy.getFailoverCandidates(pathClass, firstEndpoint, clientType, getMinCgcForPath(r.URL.Path))
+	failoverCtx.candidates = proxy.getFailoverCandidates(firstEndpoint, clientType, getMinCgcForPath(r.URL.Path))
 	if len(failoverCtx.candidates) == 0 {
 		return nil
 	}
@@ -423,18 +419,13 @@ func (proxy *BeaconProxy) newFailoverContext(r *http.Request, firstEndpoint *poo
 	return failoverCtx
 }
 
-// getFailoverCandidates returns the ready endpoints to try as failover alternatives, ordered by
-// the last endpoint known to serve this path class first, followed by the remaining endpoints
+// getFailoverCandidates returns the ready endpoints to try as failover alternatives,
 // interleaved by client type so each client implementation is covered as early as possible.
-func (proxy *BeaconProxy) getFailoverCandidates(pathClass string, firstEndpoint *pool.Client, clientType pool.ClientType, minCgc uint16) []*pool.Client {
+func (proxy *BeaconProxy) getFailoverCandidates(firstEndpoint *pool.Client, clientType pool.ClientType, minCgc uint16) []*pool.Client {
 	canonicalFork := proxy.pool.GetCanonicalFork()
 	if canonicalFork == nil {
 		return nil
 	}
-
-	preferredName := proxy.getFailoverEndpointName(pathClass)
-
-	var preferred *pool.Client
 
 	clientsByType := map[pool.ClientType][]*pool.Client{}
 	clientTypes := []pool.ClientType{}
@@ -452,11 +443,6 @@ func (proxy *BeaconProxy) getFailoverCandidates(pathClass string, firstEndpoint 
 			continue
 		}
 
-		if preferred == nil && client.GetName() == preferredName {
-			preferred = client
-			continue
-		}
-
 		cType := client.GetClientType()
 		if _, ok := clientsByType[cType]; !ok {
 			clientTypes = append(clientTypes, cType)
@@ -466,9 +452,6 @@ func (proxy *BeaconProxy) getFailoverCandidates(pathClass string, firstEndpoint 
 	}
 
 	candidates := make([]*pool.Client, 0, len(canonicalFork.ReadyClients))
-	if preferred != nil {
-		candidates = append(candidates, preferred)
-	}
 
 	for idx := 0; ; idx++ {
 		added := false
@@ -486,20 +469,6 @@ func (proxy *BeaconProxy) getFailoverCandidates(pathClass string, firstEndpoint 
 	}
 
 	return candidates
-}
-
-func (proxy *BeaconProxy) getFailoverEndpointName(pathClass string) string {
-	proxy.failoverMutex.Lock()
-	defer proxy.failoverMutex.Unlock()
-
-	return proxy.failoverEndpoints[pathClass]
-}
-
-func (proxy *BeaconProxy) setFailoverEndpoint(pathClass string, endpoint *pool.Client) {
-	proxy.failoverMutex.Lock()
-	defer proxy.failoverMutex.Unlock()
-
-	proxy.failoverEndpoints[pathClass] = endpoint.GetName()
 }
 
 func (proxy *BeaconProxy) rebalanceSessionsLoop() {

--- a/proxy/beaconproxy.go
+++ b/proxy/beaconproxy.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -64,8 +63,9 @@ var defaultFailoverPaths = []string{
 }
 
 const (
-	defaultFailoverMaxAttempts    = 8
-	defaultFailoverAttemptTimeout = 20 * time.Second
+	defaultFailoverMaxAttempts = 8
+	defaultFailoverHedgeDelay  = 20 * time.Second
+	defaultFailoverMaxParallel = 2
 )
 
 type BeaconProxy struct {
@@ -143,8 +143,12 @@ func NewBeaconProxy(config *types.ProxyConfig, beaconPool *pool.BeaconPool, prox
 		config.FailoverMaxAttempts = defaultFailoverMaxAttempts
 	}
 
-	if config.FailoverAttemptTimeout == 0 {
-		config.FailoverAttemptTimeout = defaultFailoverAttemptTimeout
+	if config.FailoverHedgeDelay == 0 {
+		config.FailoverHedgeDelay = defaultFailoverHedgeDelay
+	}
+
+	if config.FailoverMaxParallel == 0 {
+		config.FailoverMaxParallel = defaultFailoverMaxParallel
 	}
 
 	if config.RebalanceInterval > 0 {
@@ -257,41 +261,17 @@ func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, cl
 		session.removeActiveContext(contextID)
 	}()
 
-	for {
-		err = proxy.processProxyCall(w, r, callContext, session, endpoint, failoverCtx)
-		if err == nil {
-			return
-		}
-
-		if failoverCtx != nil && errors.Is(err, errFailoverAttempt) {
-			nextEndpoint := failoverCtx.nextEndpoint()
-			if nextEndpoint != nil {
-				proxy.logger.WithFields(logrus.Fields{
-					"method": r.Method,
-					"url":    utils.GetRedactedURL(r.URL.String()),
-				}).Debugf("failover: retrying on %v (%v)", nextEndpoint.GetName(), err)
-
-				endpoint = nextEndpoint
-
-				continue
-			}
-		}
-
+	err = proxy.processProxyCall(w, r, callContext, session, endpoint, failoverCtx)
+	if err != nil {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusInternalServerError)
 
-		proxy.logger.WithFields(logrus.Fields{
-			"endpoint": endpoint.GetName(),
-			"method":   r.Method,
-			"url":      utils.GetRedactedURL(r.URL.String()),
-		}).Warnf("proxy error %v", err)
+		proxy.callLogEntry(r).WithField("endpoint", endpoint.GetName()).Warnf("proxy error %v", err)
 
 		_, err = w.Write([]byte("Internal Server Error"))
 		if err != nil {
 			proxy.logger.Warnf("error writing internal server error response: %v", err)
 		}
-
-		return
 	}
 }
 

--- a/proxy/beaconproxy.go
+++ b/proxy/beaconproxy.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -53,6 +55,19 @@ var passthruResponseHeaderKeys = [...]string{
 	"Vary",
 }
 
+// defaultFailoverPaths are the api paths eligible for endpoint failover by default.
+// These are data queries where availability differs per endpoint (eg. historical states
+// are only served by nodes with state archiving enabled).
+var defaultFailoverPaths = []string{
+	"^/eth/v[0-9]+/beacon/states/",
+	"^/eth/v[0-9]+/debug/beacon/states/",
+}
+
+const (
+	defaultFailoverMaxAttempts    = 8
+	defaultFailoverAttemptTimeout = 20 * time.Second
+)
+
 type BeaconProxy struct {
 	config       *types.ProxyConfig
 	pool         *pool.BeaconPool
@@ -62,16 +77,22 @@ type BeaconProxy struct {
 
 	sessionMutex sync.Mutex
 	sessions     map[string]*SessionGroup
+
+	failoverPaths     []*regexp.Regexp
+	failoverMutex     sync.Mutex
+	failoverEndpoints map[string]string
 }
 
 func NewBeaconProxy(config *types.ProxyConfig, beaconPool *pool.BeaconPool, proxyMetrics *metrics.ProxyMetrics) (*BeaconProxy, error) {
 	proxy := BeaconProxy{
-		config:       config,
-		pool:         beaconPool,
-		proxyMetrics: proxyMetrics,
-		logger:       logrus.WithField("module", "proxy"),
-		blockedPaths: []*regexp.Regexp{},
-		sessions:     make(map[string]*SessionGroup),
+		config:            config,
+		pool:              beaconPool,
+		proxyMetrics:      proxyMetrics,
+		logger:            logrus.WithField("module", "proxy"),
+		blockedPaths:      []*regexp.Regexp{},
+		sessions:          make(map[string]*SessionGroup),
+		failoverPaths:     []*regexp.Regexp{},
+		failoverEndpoints: map[string]string{},
 	}
 
 	blockedPaths := []string{}
@@ -96,12 +117,37 @@ func NewBeaconProxy(config *types.ProxyConfig, beaconPool *pool.BeaconPool, prox
 		proxy.blockedPaths = append(proxy.blockedPaths, blockedPathPattern)
 	}
 
+	if !config.FailoverDisabled {
+		failoverPaths := config.FailoverPaths
+		if failoverPaths == nil {
+			failoverPaths = defaultFailoverPaths
+		}
+
+		for _, failoverPath := range failoverPaths {
+			failoverPathPattern, err := regexp.Compile(failoverPath)
+			if err != nil {
+				proxy.logger.Errorf("error parsing failover path pattern '%v': %v", failoverPath, err)
+				continue
+			}
+
+			proxy.failoverPaths = append(proxy.failoverPaths, failoverPathPattern)
+		}
+	}
+
 	if config.CallTimeout == 0 {
 		config.CallTimeout = 60 * time.Second
 	}
 
 	if config.SessionTimeout == 0 {
 		config.SessionTimeout = 10 * time.Minute
+	}
+
+	if config.FailoverMaxAttempts == 0 {
+		config.FailoverMaxAttempts = defaultFailoverMaxAttempts
+	}
+
+	if config.FailoverAttemptTimeout == 0 {
+		config.FailoverAttemptTimeout = defaultFailoverAttemptTimeout
 	}
 
 	if config.RebalanceInterval > 0 {
@@ -177,7 +223,7 @@ func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, cl
 		return
 	}
 
-	endpoint, err := proxy.getEndpointForCall(r, session, clientType)
+	endpoint, effectiveClientType, pinned, err := proxy.getEndpointForCall(r, session, clientType)
 	if err != nil {
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -204,8 +250,36 @@ func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, cl
 
 	session.group.requests.Add(1)
 
-	err = proxy.processProxyCall(w, r, session, endpoint)
-	if err != nil {
+	failoverCtx := proxy.newFailoverContext(r, endpoint, effectiveClientType, pinned)
+
+	callContext := proxy.newProxyCallContext(r.Context(), proxy.config.CallTimeout)
+	contextID := session.addActiveContext(callContext.cancelFn)
+
+	defer func() {
+		callContext.cancelFn()
+		session.removeActiveContext(contextID)
+	}()
+
+	for {
+		err = proxy.processProxyCall(w, r, callContext, session, endpoint, failoverCtx)
+		if err == nil {
+			return
+		}
+
+		if failoverCtx != nil && errors.Is(err, errFailoverAttempt) {
+			nextEndpoint := failoverCtx.nextEndpoint()
+			if nextEndpoint != nil {
+				proxy.logger.WithFields(logrus.Fields{
+					"method": r.Method,
+					"url":    utils.GetRedactedURL(r.URL.String()),
+				}).Debugf("failover: retrying on %v (%v)", nextEndpoint.GetName(), err)
+
+				endpoint = nextEndpoint
+
+				continue
+			}
+		}
+
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusInternalServerError)
 
@@ -219,6 +293,8 @@ func (proxy *BeaconProxy) processCall(w http.ResponseWriter, r *http.Request, cl
 		if err != nil {
 			proxy.logger.Warnf("error writing internal server error response: %v", err)
 		}
+
+		return
 	}
 }
 
@@ -233,16 +309,20 @@ func (proxy *BeaconProxy) checkBlockedPaths(reqURL *url.URL) bool {
 	return false
 }
 
-func (proxy *BeaconProxy) getEndpointForCall(r *http.Request, session *Session, clientType pool.ClientType) (*pool.Client, error) {
-	var endpoint *pool.Client
+func getMinCgcForPath(path string) uint16 {
+	if strings.HasPrefix(path, "/eth/v1/beacon/blobs/") {
+		return 64 // 64 is the minimum CGC for blobs
+	}
+
+	return 0
+}
+
+func (proxy *BeaconProxy) getEndpointForCall(r *http.Request, session *Session, clientType pool.ClientType) (endpoint *pool.Client, effectiveClientType pool.ClientType, pinned bool, err error) {
 	if proxy.config.StickyEndpoint && proxy.pool.IsClientReady(session.lastPoolClient) {
 		endpoint = session.lastPoolClient
 	}
 
-	minCgc := uint16(0)
-	if strings.HasPrefix(r.URL.Path, "/eth/v1/beacon/blobs/") {
-		minCgc = 64 // 64 is the minimum CGC for blobs
-	}
+	minCgc := getMinCgcForPath(r.URL.Path)
 
 	nextEndpoint := r.Header.Get("X-Dugtrio-Next-Endpoint")
 	if nextEndpoint == "" {
@@ -257,31 +337,169 @@ func (proxy *BeaconProxy) getEndpointForCall(r *http.Request, session *Session, 
 			clientType = nextEndpointType
 		} else if client := proxy.pool.GetEndpointByName(nextEndpoint); client != nil {
 			if client.GetCustodyGroupCount() < minCgc {
-				return nil, fmt.Errorf("endpoint %s has too low CGC (%d < %d)", nextEndpoint, client.GetCustodyGroupCount(), minCgc)
+				return nil, clientType, false, fmt.Errorf("endpoint %s has too low CGC (%d < %d)", nextEndpoint, client.GetCustodyGroupCount(), minCgc)
 			}
 
 			endpoint = client
 			clientType = pool.UnspecifiedClient
+			pinned = true
 		} else {
-			return nil, fmt.Errorf("no endpoint matches X-Dugtrio-Next-Endpoint filter")
+			return nil, clientType, false, fmt.Errorf("no endpoint matches X-Dugtrio-Next-Endpoint filter")
 		}
 	}
 
 	if minCgc > 0 && endpoint != nil {
 		if endpoint.GetCustodyGroupCount() < minCgc {
 			endpoint = nil
+			pinned = false
 		}
 	}
 
 	if endpoint == nil || (clientType != pool.UnspecifiedClient && endpoint.GetClientType() != clientType) {
 		endpoint = proxy.pool.GetReadyEndpoint(clientType, minCgc)
+		pinned = false
 
 		if minCgc == 0 {
 			session.setLastPoolClient(endpoint)
 		}
 	}
 
-	return endpoint, nil
+	return endpoint, clientType, pinned, nil
+}
+
+// newFailoverContext prepares an endpoint failover context for calls matching the configured
+// failover paths. Returns nil if the call is not eligible for failover (unmatched path,
+// explicitly pinned endpoint, non-replayable body or no alternate endpoints).
+func (proxy *BeaconProxy) newFailoverContext(r *http.Request, firstEndpoint *pool.Client, clientType pool.ClientType, pinned bool) *failoverContext {
+	if pinned || len(proxy.failoverPaths) == 0 {
+		return nil
+	}
+
+	switch r.Method {
+	case http.MethodGet, http.MethodHead, http.MethodPost:
+	default:
+		return nil
+	}
+
+	pathClass := ""
+	reqPath := r.URL.EscapedPath()
+
+	for _, failoverPathPattern := range proxy.failoverPaths {
+		if failoverPathPattern.MatchString(reqPath) {
+			pathClass = failoverPathPattern.String()
+			break
+		}
+	}
+
+	if pathClass == "" {
+		return nil
+	}
+
+	failoverCtx := &failoverContext{
+		pathClass:   pathClass,
+		maxAttempts: proxy.config.FailoverMaxAttempts,
+	}
+
+	// buffer the request body so it can be replayed on alternate endpoints
+	if r.Body != nil && r.Body != http.NoBody && r.ContentLength != 0 {
+		if r.ContentLength < 0 || r.ContentLength > failoverMaxBodySize {
+			return nil
+		}
+
+		body, err := io.ReadAll(io.LimitReader(r.Body, failoverMaxBodySize))
+		if err != nil {
+			return nil
+		}
+
+		failoverCtx.body = body
+		failoverCtx.hasBody = true
+	}
+
+	failoverCtx.candidates = proxy.getFailoverCandidates(pathClass, firstEndpoint, clientType, getMinCgcForPath(r.URL.Path))
+	if len(failoverCtx.candidates) == 0 {
+		return nil
+	}
+
+	return failoverCtx
+}
+
+// getFailoverCandidates returns the ready endpoints to try as failover alternatives, ordered by
+// the last endpoint known to serve this path class first, followed by the remaining endpoints
+// interleaved by client type so each client implementation is covered as early as possible.
+func (proxy *BeaconProxy) getFailoverCandidates(pathClass string, firstEndpoint *pool.Client, clientType pool.ClientType, minCgc uint16) []*pool.Client {
+	canonicalFork := proxy.pool.GetCanonicalFork()
+	if canonicalFork == nil {
+		return nil
+	}
+
+	preferredName := proxy.getFailoverEndpointName(pathClass)
+
+	var preferred *pool.Client
+
+	clientsByType := map[pool.ClientType][]*pool.Client{}
+	clientTypes := []pool.ClientType{}
+
+	for _, client := range canonicalFork.ReadyClients {
+		if client == firstEndpoint {
+			continue
+		}
+
+		if clientType != pool.UnspecifiedClient && client.GetClientType() != clientType {
+			continue
+		}
+
+		if minCgc > 0 && client.GetCustodyGroupCount() < minCgc {
+			continue
+		}
+
+		if preferred == nil && client.GetName() == preferredName {
+			preferred = client
+			continue
+		}
+
+		cType := client.GetClientType()
+		if _, ok := clientsByType[cType]; !ok {
+			clientTypes = append(clientTypes, cType)
+		}
+
+		clientsByType[cType] = append(clientsByType[cType], client)
+	}
+
+	candidates := make([]*pool.Client, 0, len(canonicalFork.ReadyClients))
+	if preferred != nil {
+		candidates = append(candidates, preferred)
+	}
+
+	for idx := 0; ; idx++ {
+		added := false
+
+		for _, cType := range clientTypes {
+			if idx < len(clientsByType[cType]) {
+				candidates = append(candidates, clientsByType[cType][idx])
+				added = true
+			}
+		}
+
+		if !added {
+			break
+		}
+	}
+
+	return candidates
+}
+
+func (proxy *BeaconProxy) getFailoverEndpointName(pathClass string) string {
+	proxy.failoverMutex.Lock()
+	defer proxy.failoverMutex.Unlock()
+
+	return proxy.failoverEndpoints[pathClass]
+}
+
+func (proxy *BeaconProxy) setFailoverEndpoint(pathClass string, endpoint *pool.Client) {
+	proxy.failoverMutex.Lock()
+	defer proxy.failoverMutex.Unlock()
+
+	proxy.failoverEndpoints[pathClass] = endpoint.GetName()
 }
 
 func (proxy *BeaconProxy) rebalanceSessionsLoop() {

--- a/proxy/proxycall.go
+++ b/proxy/proxycall.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +15,56 @@ import (
 	"github.com/ethpandaops/dugtrio/pool"
 	"github.com/ethpandaops/dugtrio/utils"
 )
+
+// errFailoverAttempt signals that the upstream call failed in a way that should be
+// retried on the next failover candidate endpoint.
+var errFailoverAttempt = errors.New("endpoint failover")
+
+// failoverMaxBodySize is the maximum request body size that gets buffered for replay
+// on alternate endpoints.
+const failoverMaxBodySize = 1024 * 1024
+
+// failoverContext tracks the state of an endpoint failover eligible call across attempts.
+type failoverContext struct {
+	pathClass   string
+	body        []byte
+	hasBody     bool
+	candidates  []*pool.Client
+	nextIdx     int
+	attempts    int
+	maxAttempts int
+}
+
+func (failoverCtx *failoverContext) hasNext() bool {
+	if failoverCtx.maxAttempts >= 0 && failoverCtx.attempts >= failoverCtx.maxAttempts {
+		return false
+	}
+
+	return failoverCtx.nextIdx < len(failoverCtx.candidates)
+}
+
+func (failoverCtx *failoverContext) nextEndpoint() *pool.Client {
+	if !failoverCtx.hasNext() {
+		return nil
+	}
+
+	endpoint := failoverCtx.candidates[failoverCtx.nextIdx]
+	failoverCtx.nextIdx++
+	failoverCtx.attempts++
+
+	return endpoint
+}
+
+// isFailoverStatusCode returns true for response codes that indicate the endpoint cannot
+// serve the requested data while another endpoint possibly can (eg. pruned historical states).
+func isFailoverStatusCode(statusCode int) bool {
+	switch statusCode {
+	case http.StatusNotFound, http.StatusInternalServerError, http.StatusNotImplemented, http.StatusServiceUnavailable:
+		return true
+	}
+
+	return false
+}
 
 type proxyCallContext struct {
 	context      context.Context
@@ -59,15 +111,84 @@ ctxLoop:
 	}
 }
 
-func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Request, session *Session, endpoint *pool.Client) error {
-	callContext := proxy.newProxyCallContext(r.Context(), proxy.config.CallTimeout)
-	contextID := session.addActiveContext(callContext.cancelFn)
+// doProxyAttempt sends the call to the given endpoint and returns the response to stream back.
+// It returns an errFailoverAttempt wrapped error when the attempt failed but should be retried
+// on the next failover candidate endpoint.
+func (proxy *BeaconProxy) doProxyAttempt(r *http.Request, callContext *proxyCallContext, endpoint *pool.Client, failoverCtx *failoverContext, proxyURL *url.URL, hh http.Header) (*http.Response, error) {
+	// construct request to send to origin server
+	reqBody := r.Body
+	if failoverCtx != nil && failoverCtx.hasBody {
+		reqBody = io.NopCloser(bytes.NewReader(failoverCtx.body))
+	}
 
-	defer func() {
-		callContext.cancelFn()
-		session.removeActiveContext(contextID)
-	}()
+	req := &http.Request{
+		Method:        r.Method,
+		URL:           proxyURL,
+		Header:        hh,
+		Body:          reqBody,
+		ContentLength: r.ContentLength,
+		Close:         r.Close,
+	}
 
+	// while failover candidates remain, bound this attempt so a hanging endpoint doesn't
+	// consume the whole call timeout (the last attempt runs on the remaining call timeout)
+	reqContext := callContext.context
+
+	var attemptTimer *time.Timer
+
+	if failoverCtx != nil && failoverCtx.hasNext() {
+		var attemptCancel context.CancelFunc
+
+		// the cancel func is not deferred on purpose: on an accepted response the attempt
+		// context must stay alive for body streaming, it gets cleaned up with callContext
+		reqContext, attemptCancel = context.WithCancel(callContext.context)
+		attemptTimer = time.AfterFunc(proxy.config.FailoverAttemptTimeout, attemptCancel)
+	}
+
+	start := time.Now()
+	client := &http.Client{Timeout: 0}
+	req = req.WithContext(reqContext)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if failoverCtx != nil && failoverCtx.hasNext() && !callContext.cancelled && callContext.context.Err() == nil {
+			return nil, fmt.Errorf("%w: request error on %v: %w", errFailoverAttempt, endpoint.GetName(), err)
+		}
+
+		return nil, fmt.Errorf("proxy request error: %w", err)
+	}
+
+	if callContext.cancelled {
+		resp.Body.Close()
+		return nil, fmt.Errorf("proxy context cancelled")
+	}
+
+	// add to stats
+	if proxy.proxyMetrics != nil {
+		callDuration := time.Since(start)
+		proxy.proxyMetrics.AddCall(endpoint.GetName(), fmt.Sprintf("%s%s", r.Method, r.URL.EscapedPath()), callDuration, resp.StatusCode)
+	}
+
+	if failoverCtx != nil && isFailoverStatusCode(resp.StatusCode) && failoverCtx.hasNext() {
+		resp.Body.Close()
+		return nil, fmt.Errorf("%w: status %v from %v", errFailoverAttempt, resp.StatusCode, endpoint.GetName())
+	}
+
+	if attemptTimer != nil && !attemptTimer.Stop() && reqContext.Err() != nil {
+		// the attempt timeout fired before the response got accepted
+		resp.Body.Close()
+
+		if failoverCtx.hasNext() {
+			return nil, fmt.Errorf("%w: attempt timeout on %v", errFailoverAttempt, endpoint.GetName())
+		}
+
+		return nil, fmt.Errorf("proxy attempt timeout")
+	}
+
+	return resp, nil
+}
+
+func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Request, callContext *proxyCallContext, session *Session, endpoint *pool.Client, failoverCtx *failoverContext) error {
 	endpointConfig := endpoint.GetEndpointConfig()
 
 	// get filtered headers
@@ -102,36 +223,12 @@ func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Reques
 		return fmt.Errorf("error parsing proxy url: %w", err)
 	}
 
-	// construct request to send to origin server
-	req := &http.Request{
-		Method:        r.Method,
-		URL:           proxyURL,
-		Header:        hh,
-		Body:          r.Body,
-		ContentLength: r.ContentLength,
-		Close:         r.Close,
-	}
-	start := time.Now()
-	client := &http.Client{Timeout: 0}
-	req = req.WithContext(callContext.context)
-
-	resp, err := client.Do(req)
+	resp, err := proxy.doProxyAttempt(r, callContext, endpoint, failoverCtx, proxyURL, hh) //nolint:bodyclose // body is closed via callContext.streamReader when the call context ends
 	if err != nil {
-		return fmt.Errorf("proxy request error: %w", err)
-	}
-
-	if callContext.cancelled {
-		resp.Body.Close()
-		return fmt.Errorf("proxy context cancelled")
+		return err
 	}
 
 	callContext.streamReader = resp.Body
-
-	// add to stats
-	if proxy.proxyMetrics != nil {
-		callDuration := time.Since(start)
-		proxy.proxyMetrics.AddCall(endpoint.GetName(), fmt.Sprintf("%s%s", r.Method, r.URL.EscapedPath()), callDuration, resp.StatusCode)
-	}
 
 	respContentType := resp.Header.Get("Content-Type")
 	isEventStream := respContentType == "text/event-stream" || strings.HasPrefix(r.URL.EscapedPath(), "/eth/v1/events")
@@ -151,6 +248,15 @@ func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Reques
 	respH.Set("X-Dugtrio-Endpoint-Name", endpoint.GetName())
 	respH.Set("X-Dugtrio-Endpoint-Type", endpoint.GetClientType().String())
 	respH.Set("X-Dugtrio-Endpoint-Version", endpoint.GetVersion())
+
+	if failoverCtx != nil && failoverCtx.attempts > 0 {
+		respH.Set("X-Dugtrio-Failover-Attempts", fmt.Sprintf("%d", failoverCtx.attempts))
+
+		// remember this endpoint as the preferred failover target for this path class
+		if resp.StatusCode < 400 {
+			proxy.setFailoverEndpoint(failoverCtx.pathClass, endpoint)
+		}
+	}
 
 	if isEventStream {
 		respH.Set("X-Accel-Buffering", "no")

--- a/proxy/proxycall.go
+++ b/proxy/proxycall.go
@@ -4,21 +4,19 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/ethpandaops/dugtrio/pool"
 	"github.com/ethpandaops/dugtrio/utils"
 )
-
-// errFailoverAttempt signals that the upstream call failed in a way that should be
-// retried on the next failover candidate endpoint.
-var errFailoverAttempt = errors.New("endpoint failover")
 
 // failoverMaxBodySize is the maximum request body size that gets buffered for replay
 // on alternate endpoints.
@@ -68,7 +66,7 @@ func isFailoverStatusCode(statusCode int) bool {
 type proxyCallContext struct {
 	context      context.Context
 	cancelFn     context.CancelFunc
-	cancelled    bool
+	cancelled    atomic.Bool
 	deadline     time.Time
 	updateChan   chan time.Duration
 	streamReader io.ReadCloser
@@ -97,97 +95,21 @@ ctxLoop:
 			break ctxLoop
 		case <-time.After(timeout):
 			callContext.cancelFn()
-			callContext.cancelled = true
+			callContext.cancelled.Store(true)
 
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
 
-	callContext.cancelled = true
+	callContext.cancelled.Store(true)
 
 	if callContext.streamReader != nil {
 		callContext.streamReader.Close()
 	}
 }
 
-// doProxyAttempt sends the call to the given endpoint and returns the response to stream back.
-// It returns an errFailoverAttempt wrapped error when the attempt failed but should be retried
-// on the next failover candidate endpoint.
-func (proxy *BeaconProxy) doProxyAttempt(r *http.Request, callContext *proxyCallContext, endpoint *pool.Client, failoverCtx *failoverContext, proxyURL *url.URL, hh http.Header) (*http.Response, error) {
-	// construct request to send to origin server
-	reqBody := r.Body
-	if failoverCtx != nil && failoverCtx.hasBody {
-		reqBody = io.NopCloser(bytes.NewReader(failoverCtx.body))
-	}
-
-	req := &http.Request{
-		Method:        r.Method,
-		URL:           proxyURL,
-		Header:        hh,
-		Body:          reqBody,
-		ContentLength: r.ContentLength,
-		Close:         r.Close,
-	}
-
-	// while failover candidates remain, bound this attempt so a hanging endpoint doesn't
-	// consume the whole call timeout (the last attempt runs on the remaining call timeout)
-	reqContext := callContext.context
-
-	var attemptTimer *time.Timer
-
-	if failoverCtx != nil && failoverCtx.hasNext() {
-		var attemptCancel context.CancelFunc
-
-		// the cancel func is not deferred on purpose: on an accepted response the attempt
-		// context must stay alive for body streaming, it gets cleaned up with callContext
-		reqContext, attemptCancel = context.WithCancel(callContext.context)
-		attemptTimer = time.AfterFunc(proxy.config.FailoverAttemptTimeout, attemptCancel)
-	}
-
-	start := time.Now()
-	client := &http.Client{Timeout: 0}
-	req = req.WithContext(reqContext)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		if failoverCtx != nil && failoverCtx.hasNext() && !callContext.cancelled && callContext.context.Err() == nil {
-			return nil, fmt.Errorf("%w: request error on %v: %w", errFailoverAttempt, endpoint.GetName(), err)
-		}
-
-		return nil, fmt.Errorf("proxy request error: %w", err)
-	}
-
-	if callContext.cancelled {
-		resp.Body.Close()
-		return nil, fmt.Errorf("proxy context cancelled")
-	}
-
-	// add to stats
-	if proxy.proxyMetrics != nil {
-		callDuration := time.Since(start)
-		proxy.proxyMetrics.AddCall(endpoint.GetName(), fmt.Sprintf("%s%s", r.Method, r.URL.EscapedPath()), callDuration, resp.StatusCode)
-	}
-
-	if failoverCtx != nil && isFailoverStatusCode(resp.StatusCode) && failoverCtx.hasNext() {
-		resp.Body.Close()
-		return nil, fmt.Errorf("%w: status %v from %v", errFailoverAttempt, resp.StatusCode, endpoint.GetName())
-	}
-
-	if attemptTimer != nil && !attemptTimer.Stop() && reqContext.Err() != nil {
-		// the attempt timeout fired before the response got accepted
-		resp.Body.Close()
-
-		if failoverCtx.hasNext() {
-			return nil, fmt.Errorf("%w: attempt timeout on %v", errFailoverAttempt, endpoint.GetName())
-		}
-
-		return nil, fmt.Errorf("proxy attempt timeout")
-	}
-
-	return resp, nil
-}
-
-func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Request, callContext *proxyCallContext, session *Session, endpoint *pool.Client, failoverCtx *failoverContext) error {
+// doProxyAttempt sends the call to the given endpoint and returns the upstream response.
+func (proxy *BeaconProxy) doProxyAttempt(r *http.Request, reqContext context.Context, callContext *proxyCallContext, endpoint *pool.Client, failoverCtx *failoverContext) (*http.Response, error) {
 	endpointConfig := endpoint.GetEndpointConfig()
 
 	// get filtered headers
@@ -219,10 +141,198 @@ func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Reques
 
 	proxyURL, err := url.Parse(fmt.Sprintf("%s%s%s", endpointConfig.URL, r.URL.EscapedPath(), queryArgs))
 	if err != nil {
-		return fmt.Errorf("error parsing proxy url: %w", err)
+		return nil, fmt.Errorf("error parsing proxy url: %w", err)
 	}
 
-	resp, err := proxy.doProxyAttempt(r, callContext, endpoint, failoverCtx, proxyURL, hh) //nolint:bodyclose // body is closed via callContext.streamReader when the call context ends
+	// construct request to send to origin server
+	reqBody := r.Body
+	if failoverCtx != nil {
+		// attempts may run in parallel, so the original request body cannot be shared
+		reqBody = http.NoBody
+		if failoverCtx.hasBody {
+			reqBody = io.NopCloser(bytes.NewReader(failoverCtx.body))
+		}
+	}
+
+	req := &http.Request{
+		Method:        r.Method,
+		URL:           proxyURL,
+		Header:        hh,
+		Body:          reqBody,
+		ContentLength: r.ContentLength,
+		Close:         r.Close,
+	}
+
+	start := time.Now()
+	client := &http.Client{Timeout: 0}
+	req = req.WithContext(reqContext)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("proxy request error: %w", err)
+	}
+
+	if callContext.cancelled.Load() {
+		resp.Body.Close()
+		return nil, fmt.Errorf("proxy context cancelled")
+	}
+
+	// add to stats
+	if proxy.proxyMetrics != nil {
+		callDuration := time.Since(start)
+		proxy.proxyMetrics.AddCall(endpoint.GetName(), fmt.Sprintf("%s%s", r.Method, r.URL.EscapedPath()), callDuration, resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+func (proxy *BeaconProxy) callLogEntry(r *http.Request) *logrus.Entry {
+	return proxy.logger.WithFields(logrus.Fields{
+		"method": r.Method,
+		"url":    utils.GetRedactedURL(r.URL.String()),
+	})
+}
+
+// proxyAttemptResult is the outcome of a single upstream attempt.
+type proxyAttemptResult struct {
+	endpoint *pool.Client
+	resp     *http.Response
+	err      error
+}
+
+// runProxyAttempts executes the upstream call, hedging across the failover candidates:
+// fast upstream failures (failover eligible status codes and connection errors) advance to
+// the next candidate immediately, while an attempt that stays silent for failoverHedgeDelay
+// is left running and the next candidate is raced in parallel (bounded by
+// failoverMaxParallel), so slow endpoints keep their full time to respond while hanging
+// endpoints only cost latency. The first acceptable response wins; if all candidates fail,
+// the last upstream failure response is returned so it can be passed through to the client.
+func (proxy *BeaconProxy) runProxyAttempts(r *http.Request, callContext *proxyCallContext, firstEndpoint *pool.Client, failoverCtx *failoverContext) (*http.Response, *pool.Client, error) {
+	if failoverCtx == nil {
+		resp, err := proxy.doProxyAttempt(r, callContext.context, callContext, firstEndpoint, nil)
+		return resp, firstEndpoint, err
+	}
+
+	results := make(chan *proxyAttemptResult, len(failoverCtx.candidates)+1)
+	attemptCancels := map[*pool.Client]context.CancelFunc{}
+	inflight := 0
+
+	launchAttempt := func(endpoint *pool.Client) {
+		// the cancel funcs are not deferred on purpose: the winning attempt's context must
+		// stay alive for body streaming, it gets cleaned up with callContext
+		attemptContext, attemptCancel := context.WithCancel(callContext.context) //nolint:gosec // G118: losing attempts are cancelled via abandonAttempts, the winner with callContext
+		attemptCancels[endpoint] = attemptCancel
+		inflight++
+
+		go func() {
+			resp, err := proxy.doProxyAttempt(r, attemptContext, callContext, endpoint, failoverCtx) //nolint:bodyclose // the receiver of the results channel owns and closes the body
+			results <- &proxyAttemptResult{endpoint: endpoint, resp: resp, err: err}
+		}()
+	}
+
+	// abandonAttempts cancels the still running attempts and closes their responses once they return
+	abandonAttempts := func() {
+		for _, attemptCancel := range attemptCancels {
+			attemptCancel()
+		}
+
+		if inflight > 0 {
+			go func(pending int) {
+				for i := 0; i < pending; i++ {
+					res := <-results
+					if res.resp != nil {
+						res.resp.Body.Close()
+					}
+				}
+			}(inflight)
+		}
+	}
+
+	launchAttempt(firstEndpoint)
+
+	hedgeTimer := time.NewTimer(proxy.config.FailoverHedgeDelay)
+	defer hedgeTimer.Stop()
+
+	var fallback *proxyAttemptResult
+
+	var lastErr error
+
+	for {
+		select {
+		case res := <-results:
+			inflight--
+
+			delete(attemptCancels, res.endpoint)
+
+			if res.err == nil && !isFailoverStatusCode(res.resp.StatusCode) {
+				abandonAttempts()
+
+				if fallback != nil {
+					fallback.resp.Body.Close()
+				}
+
+				return res.resp, res.endpoint, nil
+			}
+
+			if res.err != nil {
+				if callContext.cancelled.Load() || callContext.context.Err() != nil {
+					abandonAttempts()
+
+					if fallback != nil {
+						fallback.resp.Body.Close()
+					}
+
+					return nil, res.endpoint, res.err
+				}
+
+				lastErr = res.err
+			} else {
+				// the endpoint cannot serve the requested data; keep the latest failure
+				// response as fallback in case no other endpoint can serve it either
+				if fallback != nil {
+					fallback.resp.Body.Close()
+				}
+
+				fallback = res
+			}
+
+			if failoverCtx.hasNext() && inflight < proxy.config.FailoverMaxParallel {
+				nextEndpoint := failoverCtx.nextEndpoint()
+				proxy.callLogEntry(r).Debugf("failover: retrying on %v (%v failed)", nextEndpoint.GetName(), res.endpoint.GetName())
+				launchAttempt(nextEndpoint)
+				hedgeTimer.Reset(proxy.config.FailoverHedgeDelay)
+			} else if inflight == 0 {
+				// all candidates exhausted; pass the last upstream failure through
+				if fallback != nil {
+					return fallback.resp, fallback.endpoint, nil
+				}
+
+				return nil, res.endpoint, lastErr
+			}
+
+		case <-hedgeTimer.C:
+			if failoverCtx.hasNext() && inflight < proxy.config.FailoverMaxParallel {
+				nextEndpoint := failoverCtx.nextEndpoint()
+				proxy.callLogEntry(r).Debugf("failover: hedging on %v after %v of silence", nextEndpoint.GetName(), proxy.config.FailoverHedgeDelay)
+				launchAttempt(nextEndpoint)
+			}
+
+			hedgeTimer.Reset(proxy.config.FailoverHedgeDelay)
+
+		case <-callContext.context.Done():
+			abandonAttempts()
+
+			if fallback != nil {
+				fallback.resp.Body.Close()
+			}
+
+			return nil, firstEndpoint, fmt.Errorf("proxy context cancelled")
+		}
+	}
+}
+
+func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Request, callContext *proxyCallContext, session *Session, endpoint *pool.Client, failoverCtx *failoverContext) error {
+	resp, endpoint, err := proxy.runProxyAttempts(r, callContext, endpoint, failoverCtx) //nolint:bodyclose // body is closed via callContext.streamReader when the call context ends
 	if err != nil {
 		return err
 	}
@@ -315,7 +425,7 @@ func (proxy *BeaconProxy) processEventStreamResponse(callContext *proxyCallConte
 			f.Flush()
 		}
 
-		if callContext.cancelled {
+		if callContext.cancelled.Load() {
 			return written, nil
 		}
 

--- a/proxy/proxycall.go
+++ b/proxy/proxycall.go
@@ -220,7 +220,7 @@ func (proxy *BeaconProxy) runProxyAttempts(r *http.Request, callContext *proxyCa
 	launchAttempt := func(endpoint *pool.Client) {
 		// the cancel funcs are not deferred on purpose: the winning attempt's context must
 		// stay alive for body streaming, it gets cleaned up with callContext
-		attemptContext, attemptCancel := context.WithCancel(callContext.context) //nolint:gosec // G118: losing attempts are cancelled via abandonAttempts, the winner with callContext
+		attemptContext, attemptCancel := context.WithCancel(callContext.context)
 		attemptCancels[endpoint] = attemptCancel
 		inflight++
 

--- a/proxy/proxycall.go
+++ b/proxy/proxycall.go
@@ -26,7 +26,6 @@ const failoverMaxBodySize = 1024 * 1024
 
 // failoverContext tracks the state of an endpoint failover eligible call across attempts.
 type failoverContext struct {
-	pathClass   string
 	body        []byte
 	hasBody     bool
 	candidates  []*pool.Client
@@ -251,11 +250,6 @@ func (proxy *BeaconProxy) processProxyCall(w http.ResponseWriter, r *http.Reques
 
 	if failoverCtx != nil && failoverCtx.attempts > 0 {
 		respH.Set("X-Dugtrio-Failover-Attempts", fmt.Sprintf("%d", failoverCtx.attempts))
-
-		// remember this endpoint as the preferred failover target for this path class
-		if resp.StatusCode < 400 {
-			proxy.setFailoverEndpoint(failoverCtx.pathClass, endpoint)
-		}
 	}
 
 	if isEventStream {

--- a/proxy/proxycall_test.go
+++ b/proxy/proxycall_test.go
@@ -1,0 +1,317 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/dugtrio/pool"
+	"github.com/ethpandaops/dugtrio/types"
+)
+
+const testFailoverPath = "/eth/v1/beacon/states/123/validators"
+
+type testEndpoint struct {
+	client *pool.Client
+	hits   atomic.Int32
+}
+
+// newTestEndpoint spins up a mock upstream and registers it in the pool. Only calls to the
+// failover test path reach the given handler; everything else (the pool client's health
+// checks) gets an instant 404 so the background pool loop fails fast and stays quiet.
+func newTestEndpoint(t *testing.T, beaconPool *pool.BeaconPool, name string, handler http.HandlerFunc) *testEndpoint {
+	t.Helper()
+
+	endpoint := &testEndpoint{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/eth/v1/beacon/states/") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		endpoint.hits.Add(1)
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := beaconPool.AddEndpoint(&types.EndpointConfig{Name: name, URL: server.URL})
+	if err != nil {
+		t.Fatalf("error adding test endpoint %v: %v", name, err)
+	}
+
+	endpoint.client = client
+
+	return endpoint
+}
+
+func newTestProxy(t *testing.T, config *types.ProxyConfig) (*BeaconProxy, *pool.BeaconPool) {
+	t.Helper()
+
+	beaconPool, err := pool.NewBeaconPool(&types.PoolConfig{FollowDistance: 10})
+	if err != nil {
+		t.Fatalf("error creating test pool: %v", err)
+	}
+
+	proxy, err := NewBeaconProxy(config, beaconPool, nil)
+	if err != nil {
+		t.Fatalf("error creating test proxy: %v", err)
+	}
+
+	return proxy, beaconPool
+}
+
+func runTestProxyAttempts(t *testing.T, proxy *BeaconProxy, first *testEndpoint, failoverCtx *failoverContext) (*http.Response, *pool.Client, error) {
+	t.Helper()
+
+	r := httptest.NewRequest(http.MethodGet, testFailoverPath, http.NoBody)
+
+	callContext := proxy.newProxyCallContext(context.Background(), proxy.config.CallTimeout)
+	t.Cleanup(callContext.cancelFn)
+
+	return proxy.runProxyAttempts(r, callContext, first.client, failoverCtx)
+}
+
+func statusHandler(status int, body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+// hangingHandler blocks until the request is cancelled by the proxy (or the test ends).
+func hangingHandler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	t.Cleanup(func() { close(done) })
+
+	return func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-done:
+		}
+	}
+}
+
+func readTestResponse(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading response body: %v", err)
+	}
+
+	return string(body)
+}
+
+// fast upstream failures advance through the candidates until one can serve the data
+func TestFailoverSweepsFastFailures(t *testing.T) {
+	proxy, beaconPool := newTestProxy(t, &types.ProxyConfig{CallTimeout: 5 * time.Second, FailoverHedgeDelay: time.Second})
+
+	endpointA := newTestEndpoint(t, beaconPool, "a", statusHandler(http.StatusNotFound, "a-err"))
+	endpointB := newTestEndpoint(t, beaconPool, "b", statusHandler(http.StatusInternalServerError, "b-err"))
+	endpointC := newTestEndpoint(t, beaconPool, "c", statusHandler(http.StatusOK, "c-ok"))
+
+	failoverCtx := &failoverContext{candidates: []*pool.Client{endpointB.client, endpointC.client}, maxAttempts: 8}
+
+	resp, endpoint, err := runTestProxyAttempts(t, proxy, endpointA, failoverCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint != endpointC.client || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from endpoint c, got %v from %v", resp.StatusCode, endpoint.GetName())
+	}
+
+	if body := readTestResponse(t, resp); body != "c-ok" {
+		t.Fatalf("unexpected response body: %v", body)
+	}
+
+	if failoverCtx.attempts != 2 {
+		t.Fatalf("expected 2 failover attempts, got %v", failoverCtx.attempts)
+	}
+}
+
+// a silent endpoint gets hedged: the next candidate is raced after failoverHedgeDelay
+func TestFailoverHedgesSilentEndpoint(t *testing.T) {
+	proxy, beaconPool := newTestProxy(t, &types.ProxyConfig{CallTimeout: 5 * time.Second, FailoverHedgeDelay: 100 * time.Millisecond})
+
+	endpointA := newTestEndpoint(t, beaconPool, "a", hangingHandler(t))
+	endpointB := newTestEndpoint(t, beaconPool, "b", statusHandler(http.StatusOK, "b-ok"))
+
+	failoverCtx := &failoverContext{candidates: []*pool.Client{endpointB.client}, maxAttempts: 8}
+
+	start := time.Now()
+
+	resp, endpoint, err := runTestProxyAttempts(t, proxy, endpointA, failoverCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint != endpointB.client || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from endpoint b, got %v from %v", resp.StatusCode, endpoint.GetName())
+	}
+
+	resp.Body.Close()
+
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond || elapsed > time.Second {
+		t.Fatalf("expected hedged response after ~100ms, took %v", elapsed)
+	}
+}
+
+// a slow endpoint is not cancelled by the hedge delay: it keeps running and can still win
+// even after hedged candidates were started (regression test for the cascade problem where
+// no endpoint got enough time to load a state)
+func TestFailoverSlowEndpointStillWins(t *testing.T) {
+	proxy, beaconPool := newTestProxy(t, &types.ProxyConfig{CallTimeout: 5 * time.Second, FailoverHedgeDelay: 100 * time.Millisecond})
+
+	endpointA := newTestEndpoint(t, beaconPool, "a", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("a-slow-ok"))
+	})
+	endpointB := newTestEndpoint(t, beaconPool, "b", hangingHandler(t))
+	endpointC := newTestEndpoint(t, beaconPool, "c", hangingHandler(t))
+
+	failoverCtx := &failoverContext{candidates: []*pool.Client{endpointB.client, endpointC.client}, maxAttempts: 8}
+
+	resp, endpoint, err := runTestProxyAttempts(t, proxy, endpointA, failoverCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint != endpointA.client {
+		t.Fatalf("expected slow endpoint a to win, got response from %v", endpoint.GetName())
+	}
+
+	if body := readTestResponse(t, resp); body != "a-slow-ok" {
+		t.Fatalf("unexpected response body: %v", body)
+	}
+}
+
+// when no endpoint can serve the data, the last upstream failure is passed through
+func TestFailoverFallbackResponse(t *testing.T) {
+	proxy, beaconPool := newTestProxy(t, &types.ProxyConfig{CallTimeout: 5 * time.Second, FailoverHedgeDelay: time.Second})
+
+	endpointA := newTestEndpoint(t, beaconPool, "a", statusHandler(http.StatusNotFound, "a-err"))
+	endpointB := newTestEndpoint(t, beaconPool, "b", statusHandler(http.StatusNotFound, "b-err"))
+	endpointC := newTestEndpoint(t, beaconPool, "c", statusHandler(http.StatusNotFound, "c-err"))
+
+	failoverCtx := &failoverContext{candidates: []*pool.Client{endpointB.client, endpointC.client}, maxAttempts: 8}
+
+	resp, endpoint, err := runTestProxyAttempts(t, proxy, endpointA, failoverCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint != endpointC.client || resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected fallback 404 from endpoint c, got %v from %v", resp.StatusCode, endpoint.GetName())
+	}
+
+	if body := readTestResponse(t, resp); body != "c-err" {
+		t.Fatalf("unexpected response body: %v", body)
+	}
+}
+
+// hedging never runs more than failoverMaxParallel attempts at once
+func TestFailoverMaxParallel(t *testing.T) {
+	proxy, beaconPool := newTestProxy(t, &types.ProxyConfig{CallTimeout: 700 * time.Millisecond, FailoverHedgeDelay: 100 * time.Millisecond, FailoverMaxParallel: 2})
+
+	endpointA := newTestEndpoint(t, beaconPool, "a", hangingHandler(t))
+	endpointB := newTestEndpoint(t, beaconPool, "b", hangingHandler(t))
+	endpointC := newTestEndpoint(t, beaconPool, "c", hangingHandler(t))
+	endpointD := newTestEndpoint(t, beaconPool, "d", hangingHandler(t))
+
+	failoverCtx := &failoverContext{candidates: []*pool.Client{endpointB.client, endpointC.client, endpointD.client}, maxAttempts: 8}
+
+	_, _, err := runTestProxyAttempts(t, proxy, endpointA, failoverCtx) //nolint:bodyclose // the response is nil, all attempts fail
+	if err == nil {
+		t.Fatalf("expected error when all endpoints hang")
+	}
+
+	if hits := endpointA.hits.Load(); hits != 1 {
+		t.Fatalf("expected 1 attempt on endpoint a, got %v", hits)
+	}
+
+	if hits := endpointB.hits.Load(); hits != 1 {
+		t.Fatalf("expected 1 hedged attempt on endpoint b, got %v", hits)
+	}
+
+	if hits := endpointC.hits.Load() + endpointD.hits.Load(); hits != 0 {
+		t.Fatalf("expected no attempts beyond failoverMaxParallel, got %v", hits)
+	}
+}
+
+// buffered POST bodies are replayed on every attempt
+func TestFailoverReplaysRequestBody(t *testing.T) {
+	proxy, beaconPool := newTestProxy(t, &types.ProxyConfig{CallTimeout: 5 * time.Second, FailoverHedgeDelay: time.Second})
+
+	var receivedBody atomic.Pointer[string]
+
+	endpointA := newTestEndpoint(t, beaconPool, "a", statusHandler(http.StatusNotFound, "a-err"))
+	endpointB := newTestEndpoint(t, beaconPool, "b", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodyStr := string(body)
+		receivedBody.Store(&bodyStr)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("b-ok"))
+	})
+
+	reqBody := `["1","2"]`
+	failoverCtx := &failoverContext{
+		body:        []byte(reqBody),
+		hasBody:     true,
+		candidates:  []*pool.Client{endpointB.client},
+		maxAttempts: 8,
+	}
+
+	r := httptest.NewRequest(http.MethodPost, testFailoverPath, bytes.NewReader([]byte(reqBody)))
+
+	callContext := proxy.newProxyCallContext(context.Background(), proxy.config.CallTimeout)
+	t.Cleanup(callContext.cancelFn)
+
+	resp, endpoint, err := proxy.runProxyAttempts(r, callContext, endpointA.client, failoverCtx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint != endpointB.client || resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from endpoint b, got %v from %v", resp.StatusCode, endpoint.GetName())
+	}
+
+	resp.Body.Close()
+
+	if got := receivedBody.Load(); got == nil || *got != reqBody {
+		t.Fatalf("expected replayed request body %q, got %v", reqBody, got)
+	}
+}
+
+// calls without a failover context still work as plain single-attempt proxy calls
+func TestProxyAttemptWithoutFailover(t *testing.T) {
+	proxy, beaconPool := newTestProxy(t, &types.ProxyConfig{CallTimeout: 5 * time.Second})
+
+	endpointA := newTestEndpoint(t, beaconPool, "a", statusHandler(http.StatusNotFound, "a-err"))
+
+	resp, endpoint, err := runTestProxyAttempts(t, proxy, endpointA, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint != endpointA.client || resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected passthrough 404 from endpoint a, got %v from %v", resp.StatusCode, endpoint.GetName())
+	}
+
+	if body := readTestResponse(t, resp); body != "a-err" {
+		t.Fatalf("unexpected response body: %v", body)
+	}
+}

--- a/types/config.go
+++ b/types/config.go
@@ -62,8 +62,11 @@ type ProxyConfig struct {
 	FailoverPaths []string `yaml:"failoverPaths"`
 	// FailoverMaxAttempts is the maximum number of alternate endpoints to try per call (default: 8, negative = all ready endpoints)
 	FailoverMaxAttempts int `yaml:"failoverMaxAttempts" envconfig:"PROXY_FAILOVER_MAX_ATTEMPTS"`
-	// FailoverAttemptTimeout is the per-attempt timeout while alternate endpoints remain (default: 20s)
-	FailoverAttemptTimeout time.Duration `yaml:"failoverAttemptTimeout" envconfig:"PROXY_FAILOVER_ATTEMPT_TIMEOUT"`
+	// FailoverHedgeDelay is how long an attempt may stay silent before the next candidate
+	// endpoint is tried in parallel; the silent attempt keeps running (default: 20s)
+	FailoverHedgeDelay time.Duration `yaml:"failoverHedgeDelay" envconfig:"PROXY_FAILOVER_HEDGE_DELAY"`
+	// FailoverMaxParallel is the maximum number of hedged attempts running in parallel per call (default: 2)
+	FailoverMaxParallel int `yaml:"failoverMaxParallel" envconfig:"PROXY_FAILOVER_MAX_PARALLEL"`
 
 	// RebalanceInterval is how often to check for session imbalances (0 = disabled)
 	RebalanceInterval time.Duration `yaml:"rebalanceInterval"`

--- a/types/config.go
+++ b/types/config.go
@@ -56,6 +56,15 @@ type ProxyConfig struct {
 	BlockedPaths    []string      `yaml:"blockedPaths"`
 	Auth            *AuthConfig   `yaml:"auth"`
 
+	// FailoverDisabled disables retrying calls on other endpoints when an endpoint cannot serve the requested data
+	FailoverDisabled bool `yaml:"failoverDisabled" envconfig:"PROXY_FAILOVER_DISABLED"`
+	// FailoverPaths are the api path patterns eligible for endpoint failover (default: state queries)
+	FailoverPaths []string `yaml:"failoverPaths"`
+	// FailoverMaxAttempts is the maximum number of alternate endpoints to try per call (default: 8, negative = all ready endpoints)
+	FailoverMaxAttempts int `yaml:"failoverMaxAttempts" envconfig:"PROXY_FAILOVER_MAX_ATTEMPTS"`
+	// FailoverAttemptTimeout is the per-attempt timeout while alternate endpoints remain (default: 20s)
+	FailoverAttemptTimeout time.Duration `yaml:"failoverAttemptTimeout" envconfig:"PROXY_FAILOVER_ATTEMPT_TIMEOUT"`
+
 	// RebalanceInterval is how often to check for session imbalances (0 = disabled)
 	RebalanceInterval time.Duration `yaml:"rebalanceInterval"`
 	// RebalanceThreshold is the percentage difference from ideal distribution that triggers rebalancing (0-1)


### PR DESCRIPTION
# Endpoint failover for unavailable data

## Problem

Dugtrio picks one endpoint per call (sticky per session) and streams back whatever it returns. For data whose availability differs per endpoint — most notably historical states, which only nodes with state archiving serve — this means requests keep failing even when another endpoint in the pool has the data:

- `eth/v1/beacon/states/{old-slot}/validators` → 404 "State not found" (pruned) or 500 "Historical state regen is not enabled" (lodestar without `--chain.serveHistoricalState`), while e.g. nimbus endpoints serve it fine.
- Worse, some endpoints hang on these queries (observed on glamsterdam-devnet-6: a prysm node blocks indefinitely on historical state queries, and a lodestar node's nginx hangs on error responses when the request has `Accept-Encoding: gzip`), so the client just burns the whole `callTimeout`. These nodes pass all pool health checks (version/syncing/head), so they never get evicted — the hang only manifests on the failing request path.

## Change

When an upstream cannot serve the requested data, retry the call on other ready endpoints instead of returning the failure:

- **Trigger**: calls matching `failoverPaths` (default: `^/eth/v[0-9]+/beacon/states/`, `^/eth/v[0-9]+/debug/beacon/states/`) that fail with 404/500/501/503 or a connection error.
- **Sweep order**: remaining ready endpoints interleaved by client type, so every client implementation is covered as early as possible (e.g. the archiving client is found within the first few attempts rather than after trying all instances of a pruning client). Nothing is persisted between calls — each failover sweeps fresh, so load balancing is preserved.
- **Hedging instead of per-attempt timeouts**: fast upstream failures advance to the next candidate immediately. An attempt that stays *silent* for `failoverHedgeDelay` (default 20s) is **not cancelled** — it keeps running while the next candidate is raced in parallel, bounded by `failoverMaxParallel` (default 2). The first acceptable response wins; the other attempts are cancelled. So slow-but-capable endpoints keep the full call timeout to load a state (mainnet/hoodi state queries regularly take a minute+), while hanging endpoints only cost latency, not time budget — no cascade.
- **Fallback**: if no endpoint can serve the data, the last upstream failure response is passed through to the client instead of a generic 500.
- **Scope**: GET/HEAD/POST only (POST bodies up to 1MB are buffered for replay). Calls pinned to an explicit endpoint via `X-Dugtrio-Next-Endpoint` are excluded; client-type filters (prefix proxies / type filter) are honored during the sweep. Sticky session endpoints are not changed by failover. Rate limiting still charges 1 call.
- Served failover responses expose `X-Dugtrio-Failover-Attempts`.

New config (all optional, feature is on by default for state paths; disable with `failoverDisabled: true`):

```yaml
proxy:
  #failoverDisabled: false
  #failoverPaths:
  #  - ^/eth/v[0-9]+/beacon/states/
  #  - ^/eth/v[0-9]+/debug/beacon/states/
  #failoverMaxAttempts: 8
  #failoverHedgeDelay: 20s
  #failoverMaxParallel: 2
```

## Review updates

- **Removed persistence of the retried endpoint** (0c06f1f): the first version remembered the last endpoint that served a path class and tried it first, which would concentrate failover traffic from all sessions on the same node. Load balancing is prioritized instead (thanks @pk910).
- **Hedging replaces the hard per-attempt timeout** (d6874a6): the first version cancelled attempts after `failoverAttemptTimeout`, which on bigger networks (where state loads take a minute+) would cascade — no endpoint got enough time to load the state (thanks @pk910). `failoverAttemptTimeout` is replaced by `failoverHedgeDelay`/`failoverMaxParallel`.

## Testing

Unit tests (`proxy/proxycall_test.go`, run with `-race` in CI) cover the failover coordinator against mock upstreams: fast-failure sweep, hedging on silent endpoints, slow endpoint still winning after hedges started (the cascade regression), fallback passthrough when nobody has the data, the parallelism cap, POST body replay, and the non-failover passthrough path.

Manual testing of the original version against all 45 glamsterdam-devnet-6 nodes (6 client types; nimbus is the only one serving historical states there, and the pool includes endpoints that hang on these queries):

| Case | Result |
|---|---|
| `GET /eth/v1/beacon/states/10000/validators` | 200 from `nimbus-erigon-1`, `X-Dugtrio-Failover-Attempts: 4`, hanging endpoints skipped |
| `GET /eth/v2/debug/beacon/states/10000` (SSZ) | 200, 3.7MB body (5 attempts) |
| `POST .../validators` with JSON body | 200, body replayed, 1 attempt, 0.2s |
| `GET /eth/v1/beacon/headers/head` | untouched — no failover header, normal sticky endpoint |
| nonexistent state (slot 99999999) | bounded sweep (8 attempts), upstream error returned — no hang |
| `?dugtrio-next-endpoint=<node>` (pinned) | no failover, response passed through as before |
| `?dugtrio-next-endpoint=lodestar` (type filter) | sweep stayed within lodestar endpoints, upstream error passed through |

`go build` clean; `golangci-lint` reports no new findings (2 pre-existing on master).
