### PR TITLE
Fix panic when closing an event stream during in-flight delivery

### DIFF
--- a/rpc/eventstream/close_test.go
+++ b/rpc/eventstream/close_test.go
@@ -1,0 +1,84 @@
+package eventstream
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestCloseDuringInFlightSend closes the stream at the moment an event is being
+// delivered to a caller that never reads from Events. Before the fix, this could hit a
+// send on a channel that Close had already closed, panicking the whole process. Now
+// Close only signals shutdown through a dedicated channel and never closes Events or
+// Errors, so a racing send always has a safe way out.
+func TestCloseDuringInFlightSend(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "data: {\"n\":1}\n\n")
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		<-r.Context().Done()
+	}))
+	defer srv.CloseClientConnections()
+
+	stream, err := Subscribe(srv.URL, "")
+	if err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	<-stream.Ready
+
+	// Nothing reads from stream.Events, so the pending send is still parked when
+	// Close runs below - this is the exact interleaving that used to panic.
+	time.Sleep(200 * time.Millisecond)
+
+	stream.Close()
+
+	time.Sleep(300 * time.Millisecond)
+}
+
+// TestCloseIsIdempotent confirms repeated Close calls, including concurrent ones,
+// never panic or block.
+func TestCloseIsIdempotent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		<-r.Context().Done()
+	}))
+	defer srv.CloseClientConnections()
+
+	stream, err := Subscribe(srv.URL, "")
+	if err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	<-stream.Ready
+
+	done := make(chan struct{})
+
+	for i := 0; i < 5; i++ {
+		go func() {
+			stream.Close()
+			done <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Close did not return")
+		}
+	}
+}

--- a/rpc/eventstream/eventstream.go
+++ b/rpc/eventstream/eventstream.go
@@ -34,6 +34,11 @@ type Stream struct {
 	isClosed bool
 	// isClosedMutex is a mutex protecting concurrent read/write access of isClosed
 	closeMutex sync.Mutex
+	// closeChan is closed exactly once, when the stream shuts down. Every send on
+	// Events/Errors is guarded by a select against it, so a shutdown can never race a
+	// send into a panic. Events and Errors themselves are never closed, since closing
+	// them concurrently with an in-flight send would reintroduce the same problem.
+	closeChan chan struct{}
 }
 
 type StreamEvent interface {
@@ -85,6 +90,7 @@ func SubscribeWith(lastEventID string, client *http.Client, request *http.Reques
 		Events:      make(chan StreamEvent),
 		Errors:      make(chan error, 10),
 		Ready:       make(chan bool),
+		closeChan:   make(chan struct{}),
 	}
 	stream.c.CheckRedirect = checkRedirect
 
@@ -109,8 +115,7 @@ func (stream *Stream) Close() {
 		}
 
 		stream.isClosed = true
-		close(stream.Errors)
-		close(stream.Events)
+		close(stream.closeChan)
 	}()
 }
 
@@ -183,19 +188,25 @@ func (stream *Stream) receiveEvents(r io.ReadCloser) {
 			return
 		}
 
-		if err != nil {
-			stream.Errors <- err
+		stream.closeMutex.Unlock()
 
-			stream.closeMutex.Unlock()
+		if err != nil {
+			select {
+			case stream.Errors <- err:
+			case <-stream.closeChan:
+			}
 
 			return
 		}
 
-		stream.closeMutex.Unlock()
-
 		pub, ok := ev.(StreamEvent)
 		if !ok {
-			stream.Errors <- fmt.Errorf("invalid event type: %T", ev)
+			select {
+			case stream.Errors <- fmt.Errorf("invalid event type: %T", ev):
+			case <-stream.closeChan:
+				return
+			}
+
 			continue
 		}
 
@@ -207,7 +218,11 @@ func (stream *Stream) receiveEvents(r io.ReadCloser) {
 			stream.lastEventID = pub.Id()
 		}
 
-		stream.Events <- pub
+		select {
+		case stream.Events <- pub:
+		case <-stream.closeChan:
+			return
+		}
 	}
 }
 
@@ -238,7 +253,11 @@ func (stream *Stream) retryRestartStream() {
 			return
 		}
 
-		stream.Errors <- err
+		select {
+		case stream.Errors <- err:
+		case <-stream.closeChan:
+			return
+		}
 
 		backoff = 10 * time.Second
 	}


### PR DESCRIPTION
## Summary

Close set a flag and closed the Events and Errors channels while the receive loop could still be mid send on them. If a shutdown raced a delivered event, the send hit a closed channel and panicked the whole process. This was not an edge case: it can happen on any upstream reconnect or error, which is routine.

Close now only closes a dedicated signal channel. Every send on Events and Errors selects against that channel instead of racing a close, so a shutdown always has a safe path out and the data channels are never closed while a sender might still be using them.

## Test plan

- Added a test that closes the stream while an event delivery is parked with nothing reading Events, reproducing the exact interleaving that used to panic.
- Added a test that calls Close concurrently and repeatedly to confirm it stays safe and non blocking.
- `go build ./...` and `go vet ./rpc/eventstream/...` pass.
- `go test -race ./rpc/eventstream/...` passes.