### PR TITLE
Fix Close deadlocking when the event channel is full

### DIFF
--- a/rpc/beaconstream.go
+++ b/rpc/beaconstream.go
@@ -95,11 +95,19 @@ func (bs *BeaconStream) startStream() {
 			case <-bs.killChan:
 				running = false
 			case <-stream.Ready:
-				bs.ReadyChan <- true
+				select {
+				case bs.ReadyChan <- true:
+				case <-bs.killChan:
+					running = false
+				}
 			case err := <-stream.Errors:
 				logger.WithField("client", bs.client.name).Warnf("beacon block stream error: %v", err)
 
-				bs.ReadyChan <- false
+				select {
+				case bs.ReadyChan <- false:
+				case <-bs.killChan:
+					running = false
+				}
 			}
 		}
 	}
@@ -183,9 +191,9 @@ func (bs *BeaconStream) processBlockEvent(evt eventsource.Event) {
 		return
 	}
 
-	bs.EventChan <- &BeaconStreamEvent{
-		Event: StreamBlockEvent,
-		Data:  &parsed,
+	select {
+	case bs.EventChan <- &BeaconStreamEvent{Event: StreamBlockEvent, Data: &parsed}:
+	case <-bs.killChan:
 	}
 }
 
@@ -199,9 +207,10 @@ func (bs *BeaconStream) processHeadEvent(evt eventsource.Event) {
 	}
 
 	bs.lastHeadSeen = time.Now()
-	bs.EventChan <- &BeaconStreamEvent{
-		Event: StreamHeadEvent,
-		Data:  &parsed,
+
+	select {
+	case bs.EventChan <- &BeaconStreamEvent{Event: StreamHeadEvent, Data: &parsed}:
+	case <-bs.killChan:
 	}
 }
 
@@ -214,8 +223,8 @@ func (bs *BeaconStream) processFinalizedEvent(evt eventsource.Event) {
 		return
 	}
 
-	bs.EventChan <- &BeaconStreamEvent{
-		Event: StreamFinalizedEvent,
-		Data:  &parsed,
+	select {
+	case bs.EventChan <- &BeaconStreamEvent{Event: StreamFinalizedEvent, Data: &parsed}:
+	case <-bs.killChan:
 	}
 }

--- a/rpc/beaconstream_close_test.go
+++ b/rpc/beaconstream_close_test.go
@@ -1,0 +1,64 @@
+package rpc
+
+import (
+	"testing"
+	"time"
+)
+
+type fakeBlockEvent struct {
+	data string
+}
+
+func (e fakeBlockEvent) Id() string    { return "" }
+func (e fakeBlockEvent) Event() string { return "block" }
+func (e fakeBlockEvent) Data() string  { return e.data }
+func (e fakeBlockEvent) Retry() int64  { return 0 }
+
+// TestCloseDoesNotDeadlockOnFullEventChan reproduces the exact shape of the previous
+// deadlock: a producer holds runMutex (as startStream does for its whole lifetime) and
+// is parked trying to push an event onto a full EventChan that nothing drains. Close
+// must still be able to return instead of blocking forever on runMutex.
+func TestCloseDoesNotDeadlockOnFullEventChan(t *testing.T) {
+	root := "0x0000000000000000000000000000000000000000000000000000000000000000"
+	evt := fakeBlockEvent{data: `{"slot":"1","block":"` + root + `","execution_optimistic":false}`}
+
+	bs := &BeaconStream{
+		running:   true,
+		killChan:  make(chan bool),
+		ReadyChan: make(chan bool, 10),
+		EventChan: make(chan *BeaconStreamEvent, 10),
+	}
+
+	producerBlocked := make(chan struct{})
+
+	go func() {
+		bs.runMutex.Lock()
+		defer bs.runMutex.Unlock()
+
+		// Fill the buffer directly, then call the real production method for the
+		// send that would have blocked forever before the fix.
+		for i := 0; i < 10; i++ {
+			bs.EventChan <- &BeaconStreamEvent{Event: StreamBlockEvent}
+		}
+
+		close(producerBlocked)
+
+		bs.processBlockEvent(evt)
+	}()
+
+	<-producerBlocked
+	time.Sleep(100 * time.Millisecond) // let processBlockEvent reach its send
+
+	closeDone := make(chan struct{})
+
+	go func() {
+		bs.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close did not return: still deadlocked on a full EventChan")
+	}
+}


### PR DESCRIPTION
## Summary

startStream held the run mutex for the entire life of the stream and sent events to EventChan with a plain, unselectable send. If the consumer fell behind during a burst of events, that send would block while still holding the mutex. Close needs the same mutex to finish, so it would then wait forever, silently leaving that endpoint stuck out of rotation until the process restarted.

The trigger condition correlates with node degradation, since a struggling node both slows the consumer and produces more retries and events, so this tends to fire exactly when an endpoint is already having trouble.

All three event sends and both ready state sends now also select against the kill channel, so a closing stream can abandon a full buffer instead of blocking, and Close always returns.

## Test plan

- Added a test that reproduces the deadlock shape directly: a producer holds the run mutex and is parked trying to push onto a full EventChan, then Close must still return.
- Confirmed the new test fails on the old code and passes with the fix.
- `go build ./...` and `go vet ./rpc/...` pass.
- `go test -race ./rpc/...` passes.