### PR TITLE
Fix panic on Basic auth when no auth config is set

### DIFF
--- a/proxy/autorization.go
+++ b/proxy/autorization.go
@@ -27,6 +27,10 @@ func (proxy *BeaconProxy) CheckAuthorization(r *http.Request) (string, bool) {
 		return "", !requireAuth
 	}
 
+	if proxy.config.Auth == nil {
+		return "", !requireAuth
+	}
+
 	// Check the auth type
 	if !strings.HasPrefix(authHeader, "Basic ") {
 		return "", !requireAuth

--- a/proxy/autorization_test.go
+++ b/proxy/autorization_test.go
@@ -1,0 +1,59 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethpandaops/dugtrio/types"
+)
+
+// TestCheckAuthorizationBasicAuthWithNilConfig sends a Basic-auth header at a proxy
+// that has no auth block configured at all. Auth is nil in that case, and the
+// basic-auth branch used to dereference it unconditionally, panicking on every such
+// request regardless of who sent it.
+func TestCheckAuthorizationBasicAuthWithNilConfig(t *testing.T) {
+	proxy := &BeaconProxy{config: &types.ProxyConfig{}}
+
+	req := httptest.NewRequest(http.MethodGet, "/eth/v1/node/version", nil)
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")))
+
+	identifier, ok := proxy.CheckAuthorization(req)
+
+	if identifier != "" {
+		t.Fatalf("expected empty identifier, got %q", identifier)
+	}
+
+	if !ok {
+		t.Fatal("expected the request to be allowed since auth is not required by default")
+	}
+}
+
+// TestCheckAuthorizationBasicAuthWithConfiguredPassword confirms normal Basic-auth
+// still works correctly when an auth block is configured, so the nil guard does not
+// interfere with the real authentication path.
+func TestCheckAuthorizationBasicAuthWithConfiguredPassword(t *testing.T) {
+	proxy := &BeaconProxy{config: &types.ProxyConfig{
+		Auth: &types.AuthConfig{
+			Required: true,
+			Password: "correct-password",
+		},
+	}}
+
+	correctReq := httptest.NewRequest(http.MethodGet, "/eth/v1/node/version", nil)
+	correctReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("alice:correct-password")))
+
+	identifier, ok := proxy.CheckAuthorization(correctReq)
+	if identifier != "alice" || !ok {
+		t.Fatalf("expected (alice, true), got (%q, %v)", identifier, ok)
+	}
+
+	wrongReq := httptest.NewRequest(http.MethodGet, "/eth/v1/node/version", nil)
+	wrongReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("alice:wrong-password")))
+
+	identifier, ok = proxy.CheckAuthorization(wrongReq)
+	if ok {
+		t.Fatalf("expected the wrong password to be rejected, got (%q, %v)", identifier, ok)
+	}
+}


### PR DESCRIPTION
## Summary

The api key branch checked for a nil Auth config before using it, but the Basic auth fallback did not, so it dereferenced Auth.Password directly. Any request with an Authorization: Basic header hit this on a proxy running without an auth block at all, which is a normal, supported configuration rather than an edge case.

Added the same nil check to the Basic auth path so it degrades to the same allow or deny behavior used everywhere else in this function instead of crashing the request.

## Test plan

- Added a test sending a Basic auth header at a proxy with no auth config, confirming it no longer panics and is allowed through as expected when auth is not required.
- Added a test covering the normal Basic auth path with a configured password, correct and incorrect, to confirm the nil check does not change existing behavior.
- Confirmed the new nil config test fails on the old code and passes with the fix.
- `go build ./...`, `go vet ./proxy/...`, and `go test ./proxy/...` pass.