### PR TITLE
Make session sticky-endpoint pointer safe for concurrent access

### DIFF
--- a/proxy/beaconproxy.go
+++ b/proxy/beaconproxy.go
@@ -295,8 +295,8 @@ func getMinCgcForPath(path string) uint16 {
 }
 
 func (proxy *BeaconProxy) getEndpointForCall(r *http.Request, session *Session, clientType pool.ClientType) (endpoint *pool.Client, effectiveClientType pool.ClientType, pinned bool, err error) {
-	if proxy.config.StickyEndpoint && proxy.pool.IsClientReady(session.lastPoolClient) {
-		endpoint = session.lastPoolClient
+	if stickyClient := session.lastPoolClient.Load(); proxy.config.StickyEndpoint && proxy.pool.IsClientReady(stickyClient) {
+		endpoint = stickyClient
 	}
 
 	minCgc := getMinCgcForPath(r.URL.Path)
@@ -494,8 +494,8 @@ func (proxy *BeaconProxy) rebalanceSessions() {
 	totalSessions := 0
 
 	for _, session := range allSessions {
-		if session.lastPoolClient != nil && slices.Contains(readyClients, session.lastPoolClient) {
-			endpointTotals[session.lastPoolClient]++
+		if client := session.lastPoolClient.Load(); client != nil && slices.Contains(readyClients, client) {
+			endpointTotals[client]++
 			totalSessions++
 		}
 	}
@@ -564,7 +564,7 @@ func (proxy *BeaconProxy) rebalanceSessions() {
 			constrained := make(map[pool.ClientType][]*Session, 2)
 
 			for _, session := range allSessions {
-				if session.lastPoolClient != srcClient {
+				if session.lastPoolClient.Load() != srcClient {
 					continue
 				}
 

--- a/proxy/session.go
+++ b/proxy/session.go
@@ -39,7 +39,7 @@ type Session struct {
 	group          *SessionGroup
 	prefix         pool.ClientType
 	lastSeen       time.Time
-	lastPoolClient *pool.Client
+	lastPoolClient atomic.Pointer[pool.Client]
 	lastRebalance  time.Time
 	activeContexts struct {
 		sync.Mutex
@@ -263,7 +263,7 @@ func (session *Session) GetPrefix() pool.ClientType {
 }
 
 func (session *Session) GetLastPoolClient() *pool.Client {
-	return session.lastPoolClient
+	return session.lastPoolClient.Load()
 }
 
 func (session *Session) addActiveContext(cancel context.CancelFunc) uint64 {
@@ -295,8 +295,8 @@ func (session *Session) cancelActiveConnections() {
 }
 
 func (session *Session) setLastPoolClient(client *pool.Client) {
-	if session.lastPoolClient != client {
+	previous := session.lastPoolClient.Swap(client)
+	if previous != client {
 		session.cancelActiveConnections()
-		session.lastPoolClient = client
 	}
 }

--- a/proxy/session_lastpoolclient_test.go
+++ b/proxy/session_lastpoolclient_test.go
@@ -1,0 +1,82 @@
+package proxy
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ethpandaops/dugtrio/pool"
+)
+
+// TestSetLastPoolClientConcurrentAccess drives setLastPoolClient and GetLastPoolClient
+// from several goroutines at once, the same way the request path, the rebalancer, and
+// the frontend sessions handler touch a session's sticky endpoint pointer with no
+// common lock between them. It exists to keep this safe under -race going forward.
+func TestSetLastPoolClientConcurrentAccess(t *testing.T) {
+	s := &Session{}
+	s.init()
+
+	clientA := &pool.Client{}
+	clientB := &pool.Client{}
+
+	var wg sync.WaitGroup
+
+	const iters = 20000
+
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			s.setLastPoolClient(clientA)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			s.setLastPoolClient(clientB)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_ = s.GetLastPoolClient()
+		}
+	}()
+
+	wg.Wait()
+
+	final := s.GetLastPoolClient()
+	if final != clientA && final != clientB {
+		t.Fatalf("expected the final client to be one of the two written values, got %v", final)
+	}
+}
+
+// TestSetLastPoolClientOnlyCancelsOnChange verifies the client-change decision itself
+// is now made from a single atomic exchange rather than a separate read followed by a
+// separate write, so two callers racing to set the same session can no longer disagree
+// about whether the target actually changed.
+func TestSetLastPoolClientOnlyCancelsOnChange(t *testing.T) {
+	s := &Session{}
+	s.init()
+
+	client := &pool.Client{}
+
+	s.setLastPoolClient(client)
+
+	cancelled := false
+	s.addActiveContext(func() { cancelled = true })
+
+	s.setLastPoolClient(client) // same client again - should not cancel anything
+
+	if cancelled {
+		t.Fatal("setting the same client again should not cancel active connections")
+	}
+
+	s.setLastPoolClient(&pool.Client{}) // different client - should cancel
+
+	if !cancelled {
+		t.Fatal("setting a different client should cancel active connections")
+	}
+}


### PR DESCRIPTION
## Summary

Session.lastPoolClient was a plain pointer read and written from the request path, the rebalancer, and the frontend sessions handler with no lock shared between them. Two ordinary concurrent requests on the same session were enough to race on it, no unusual timing or misbehaving client required.

The read-then-write in setLastPoolClient made this worse than a simple race: two callers could each read the old value, both decide independently whether the target had changed, and one of those decisions could be wrong, sometimes skipping the connection cancel that is supposed to go along with a real change.

lastPoolClient is now an atomic.Pointer, and setLastPoolClient swaps it in one atomic step so the change decision comes from a single consistent exchange instead of a separate read and write. Call sites in the endpoint selection and rebalance paths were updated to load through the same accessor.

## Test plan

- Added a test that drives setLastPoolClient and GetLastPoolClient from several goroutines at once, matching how the request path, rebalancer, and frontend touch this field in production.
- Added a test confirming the cancel decision is now consistent: setting the same client again does not cancel active connections, and setting a different client does.
- Confirmed the concurrency test fails under -race on the old code and passes with the fix.
- Existing failover and proxy call tests still pass, confirming no behavior change to endpoint selection.
- `go build ./...`, `go vet ./proxy/...`, and `go test -race ./proxy/...` pass.